### PR TITLE
feat: Disable PMTUD if using DA

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -519,7 +519,7 @@ namespace Unity.Netcode.Transports.UTP
                 sendQueueCapacity: m_MaxPacketQueueSize,
                 receiveQueueCapacity: m_MaxPacketQueueSize,
                 heartbeatTimeoutMS: m_HeartbeatTimeoutMS);
-            
+
             // Disable PMTU discovery if using DA, leave it at its default otherwise.
             if (OnCurrentTopology() == NetworkTopologyTypes.DistributedAuthority)
             {

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -519,6 +519,14 @@ namespace Unity.Netcode.Transports.UTP
                 sendQueueCapacity: m_MaxPacketQueueSize,
                 receiveQueueCapacity: m_MaxPacketQueueSize,
                 heartbeatTimeoutMS: m_HeartbeatTimeoutMS);
+            
+            // Disable PMTU discovery if using DA, leave it at its default otherwise.
+            if (OnCurrentTopology() == NetworkTopologyTypes.DistributedAuthority)
+            {
+                var config = settings.GetNetworkConfigParameters();
+                config.performPathMtuDiscovery = false;
+                settings.AddRawParameterStruct(ref config);
+            }
 
             // Configure Relay if in use.
             if (m_ProtocolType == ProtocolType.RelayUnityTransport)


### PR DESCRIPTION
## Purpose of this PR

At some point UTP will start enabling path MTU discovery (PMTUD) by default. When that happens, we don't want it enabled in NGO if using distributed authority since the CMB server doesn't support that part of the UTP protocol.

### Jira ticket
N/A

### Changelog

None

## Documentation

No documentation changes or additions were necessary.

## Testing & QA

### Functional Testing

_Manual testing :_
- [X] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

## Up-port

3.X: PR #4127

## Backports

N/A
