### PR TITLE
fix: NetworkTransform interpolation render time

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -22,8 +22,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Issue where non-authority `NetworkTransform` instances derived their interpolation time from the local clock instead of the server clock that state updates are stamped on, which starved the interpolator and reduced interpolation to snapping between state updates. (#TBD)
-- Issue where `NetworkTransform.GetTickLatencyInSeconds` returned a time derived from the local clock, which did not match the time the interpolators actually use. (#TBD)
+- Issue where `NetworkTransform` interpolated towards a point in time taken from the local clock rather than the server clock that state updates are stamped on, which starved the interpolator on clients and reduced interpolation to snapping between state updates. (#TBD)
+- Issue where `NetworkTransform.GetTickLatencyInSeconds` returned a time based on the local clock instead of the server clock used for interpolation. (#TBD)
 
 ### Security
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -22,8 +22,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
-- Issue where `NetworkTransform` interpolated towards a point in time taken from the local clock rather than the server clock that state updates are stamped on, which starved the interpolator on clients and reduced interpolation to snapping between state updates. (#TBD)
-- Issue where `NetworkTransform.GetTickLatencyInSeconds` returned a time based on the local clock instead of the server clock used for interpolation. (#TBD)
+- Issue where `NetworkTransform` interpolated towards a point in time taken from the local clock rather than the server clock that state updates are stamped on, which starved the interpolator on clients and reduced interpolation to snapping between state updates. (#4133)
+- Issue where `NetworkTransform.GetTickLatencyInSeconds` returned a time based on the local clock instead of the server clock used for interpolation. (#4133)
 
 ### Security
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -22,6 +22,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Issue where non-authority `NetworkTransform` instances derived their interpolation time from the local clock instead of the server clock that state updates are stamped on, which starved the interpolator and reduced interpolation to snapping between state updates. (#TBD)
+- Issue where `NetworkTransform.GetTickLatencyInSeconds` returned a time derived from the local clock, which did not match the time the interpolators actually use. (#TBD)
 
 ### Security
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -23,7 +23,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
 ### Fixed
 
 - Issue where `NetworkTransform` interpolated towards a point in time taken from the local clock rather than the server clock that state updates are stamped on, which starved the interpolator on clients and reduced interpolation to snapping between state updates. (#4133)
-- Issue where `NetworkTransform.GetTickLatencyInSeconds` returned a time based on the local clock instead of the server clock used for interpolation. (#4133)
+- Issue where `NetworkTransform.GetTickLatencyInSeconds` returned an absolute network timestamp that grew for as long as the session ran, rather than the tick latency as a duration in seconds that it is documented to return. (#4133)
 
 ### Security
 

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
@@ -4700,7 +4700,10 @@ namespace Unity.Netcode.Components
         {
             if (networkManager.IsListening)
             {
-                return (float)networkManager.ServerTime.TimeTicksAgo(networkManager.NetworkTimeSystem.TickLatency + InterpolationBufferTickOffset).Time;
+                // The number of ticks the interpolators run behind, as a duration. This is not a point in time:
+                // it does not grow as the session runs.
+                var ticksBehind = networkManager.NetworkTimeSystem.TickLatency + InterpolationBufferTickOffset;
+                return (float)(ticksBehind * networkManager.ServerTime.FixedDeltaTimeAsDouble);
             }
             return 0f;
         }

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
@@ -4230,14 +4230,27 @@ namespace Unity.Netcode.Components
         // Non-Authority
         private void UpdateInterpolation()
         {
-            // Use the local time because:
-            // Client-Server:
-            // Local time is server time on a host or server.
-            // Local time on clients takes latency into consideration.
-            // Distributed authority:
-            // Local time is used by the authority.
-            // Local time on non-authority takes latency into consid]eration.
-            var timeSystem = m_CachedNetworkManager.LocalTime;
+            // Use the server time, because that is the clock the measurements being interpolated between are
+            // stamped on: a state's SentTime is derived from its NetworkTick, which is a server tick.
+            //
+            // Deriving the render time from LocalTime instead mixes two clocks. LocalTime leads ServerTime by
+            // roughly the tick latency, so subtracting the tick latency from it lands the render time back at
+            // (approximately) ServerTime rather than behind it. "Approximately" is the problem: the lead is
+            // fractional while the subtraction is a whole number of ticks, and a state's SentTime is floored to
+            // a tick boundary on top of that. The render time therefore ends up at or slightly ahead of the
+            // newest state that can exist, leaving the interpolator with nothing to interpolate towards. A
+            // measured session had the render time ahead of ServerTime on 100% of frames, with the interpolator
+            // never holding more than one measurement.
+            //
+            // Measuring from ServerTime instead makes the offset the whole tick latency rather than whatever is
+            // left of it, which is self correcting: as the round trip time grows, NetworkTimeSystem.TickLatency
+            // grows and the render time moves further back with it.
+            //
+            // Note this is a no-op on a host or server, where LocalTime and ServerTime are the same.
+            // TODO-JIRA-TICKET:
+            // Confirm the distributed authority case. Authority instances interpolate nothing, so this should
+            // not reach them, but ServerTime's meaning under a CMB service session should be verified.
+            var timeSystem = m_CachedNetworkManager.ServerTime;
             var currentTime = timeSystem.Time;
 #if COM_UNITY_MODULES_PHYSICS || COM_UNITY_MODULES_PHYSICS2D
             var cachedDeltaTime = m_UseRigidbodyForMotion ? m_CachedNetworkManager.RealTimeProvider.FixedDeltaTime : m_CachedNetworkManager.RealTimeProvider.DeltaTime;
@@ -4701,7 +4714,7 @@ namespace Unity.Netcode.Components
         {
             if (networkManager.IsListening)
             {
-                return (float)networkManager.LocalTime.TimeTicksAgo(networkManager.NetworkTimeSystem.TickLatency + InterpolationBufferTickOffset).Time;
+                return (float)networkManager.ServerTime.TimeTicksAgo(networkManager.NetworkTimeSystem.TickLatency + InterpolationBufferTickOffset).Time;
             }
             return 0f;
         }

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
@@ -4230,26 +4230,12 @@ namespace Unity.Netcode.Components
         // Non-Authority
         private void UpdateInterpolation()
         {
-            // Use the server time, because that is the clock the measurements being interpolated between are
-            // stamped on: a state's SentTime is derived from its NetworkTick, which is a server tick.
-            //
-            // Deriving the render time from LocalTime instead mixes two clocks. LocalTime leads ServerTime by
-            // roughly the tick latency, so subtracting the tick latency from it lands the render time back at
-            // (approximately) ServerTime rather than behind it. "Approximately" is the problem: the lead is
-            // fractional while the subtraction is a whole number of ticks, and a state's SentTime is floored to
-            // a tick boundary on top of that. The render time therefore ends up at or slightly ahead of the
-            // newest state that can exist, leaving the interpolator with nothing to interpolate towards. A
-            // measured session had the render time ahead of ServerTime on 100% of frames, with the interpolator
-            // never holding more than one measurement.
-            //
-            // Measuring from ServerTime instead makes the offset the whole tick latency rather than whatever is
-            // left of it, which is self correcting: as the round trip time grows, NetworkTimeSystem.TickLatency
-            // grows and the render time moves further back with it.
-            //
-            // Note this is a no-op on a host or server, where LocalTime and ServerTime are the same.
-            // TODO-JIRA-TICKET:
-            // Confirm the distributed authority case. Authority instances interpolate nothing, so this should
-            // not reach them, but ServerTime's meaning under a CMB service session should be verified.
+            // Use the server time, since that is the clock the states being interpolated between are stamped on
+            // (a state's SentTime is derived from its NetworkTick). Deriving the render time from LocalTime
+            // subtracts the tick latency from a clock that already leads ServerTime by roughly that much, which
+            // leaves the render time at or ahead of the newest state that can exist and starves the interpolator.
+            // Measuring from ServerTime is also self correcting, as the tick latency grows with the round trip
+            // time. This is a no-op on a host or server, where both clocks are the same.
             var timeSystem = m_CachedNetworkManager.ServerTime;
             var currentTime = timeSystem.Time;
 #if COM_UNITY_MODULES_PHYSICS || COM_UNITY_MODULES_PHYSICS2D

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformInterpolationRenderTimeTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformInterpolationRenderTimeTests.cs
@@ -13,19 +13,10 @@ namespace Unity.Netcode.RuntimeTests
     /// clock that the state updates it is interpolating between are stamped on.
     /// </summary>
     /// <remarks>
-    /// A <see cref="NetworkTransform"/> state's SentTime is derived from its NetworkTick, which is a server
-    /// tick, so the render time has to be measured from ServerTime. Measuring it from LocalTime mixes two
-    /// clocks: LocalTime leads ServerTime, so subtracting the tick latency from LocalTime lands the render time
-    /// back at approximately ServerTime rather than a whole tick latency behind it. The interpolator is then
-    /// asked to render a point in time at (or ahead of) the newest state that can possibly exist, so it has
-    /// nothing left to interpolate towards.
-    ///
-    /// What this test measures is how far behind ServerTime the state currently being interpolated towards was
-    /// sent. Because the target is selected against the render time, this has to be at least the tick latency:
-    /// the render time is ServerTime minus the tick latency, and only states sent at or before the render time
-    /// are eligible. Deriving the render time from LocalTime instead eats into that margin by however far the
-    /// two clocks are apart, and can push the target past ServerTime entirely (a negative value below, meaning
-    /// the interpolator is chasing a state that the server clock says has not happened yet).
+    /// Measures how far behind ServerTime the state being interpolated towards was sent. The render time is
+    /// ServerTime minus the tick latency and only states sent at or before it are eligible, so that measurement
+    /// can never be less than the tick latency. Deriving the render time from LocalTime eats into that margin by
+    /// however far the two clocks are apart, and can push the target past ServerTime entirely.
     /// </remarks>
     [TestFixture(HostOrServer.Host, NetworkTransform.InterpolationTypes.Lerp)]
     [TestFixture(HostOrServer.Host, NetworkTransform.InterpolationTypes.SmoothDampening)]
@@ -33,12 +24,9 @@ namespace Unity.Netcode.RuntimeTests
     {
         protected override int NumberOfClients => 1;
 
-        // How far LocalTime is pushed ahead of ServerTime, in ticks. An in-process integration test has
-        // effectively no round trip time and the separation between the two clocks is
-        // (half RTT + LocalBufferSec + ServerBufferSec), so without widening the local buffer the two clocks
-        // sit close enough together that which one is used barely shows. This is deliberately large enough to
-        // exceed NetworkTimeSystem's hard reset threshold (0.2s) so the offset snaps rather than converging at
-        // the default adjustment ratio of 0.01s per second, which would take over ten seconds.
+        // How far LocalTime is pushed ahead of ServerTime, in ticks. An in-process test has no round trip time
+        // to separate the two clocks, and this is large enough to exceed NetworkTimeSystem's hard reset
+        // threshold so the offset snaps instead of converging at its default adjustment ratio.
         private const int k_LocalBufferTicks = 12;
 
         // The separation the clocks must actually reach before any measurement is taken.
@@ -47,11 +35,10 @@ namespace Unity.Netcode.RuntimeTests
         // Ticks of authority motion after the clocks have separated, so the interpolator reaches steady state.
         private const int k_WarmUpTicks = 20;
 
-        // The number of rendered frames sampled once the warm up has completed.
         private const int k_SampledFrames = 90;
 
-        // The distance the authority moves each tick. Large enough that every tick produces a state update
-        // rather than being filtered out by the position threshold.
+        // Far enough each tick that every tick produces a state update rather than being filtered out by the
+        // position threshold.
         private const float k_DistancePerTick = 1.37f;
 
         private readonly NetworkTransform.InterpolationTypes m_InterpolationType;
@@ -223,9 +210,7 @@ namespace Unity.Netcode.RuntimeTests
                 var meanBuffered = totalBuffered[instance] / (float)samples[instance];
                 var tickLatency = networkManager.NetworkTimeSystem.TickLatency;
 
-                // Only states sent at or before the render time are eligible to be interpolated towards, and the
-                // render time is the server clock minus the tick latency, so the target can never be newer than
-                // that. Anything less means the render time was taken from a clock that runs ahead of the one
+                // Anything less than the tick latency means the render time came from a clock that leads the one
                 // the states are stamped on.
                 Assert.GreaterOrEqual(meanTargetLagTicks, tickLatency,
                     $"[{m_InterpolationType}] {instance.name} was interpolating towards a state sent " +

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformInterpolationRenderTimeTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformInterpolationRenderTimeTests.cs
@@ -1,5 +1,4 @@
 using System.Collections;
-using System.Collections.Generic;
 using NUnit.Framework;
 using Unity.Netcode.Components;
 using Unity.Netcode.TestHelpers.Runtime;
@@ -18,8 +17,8 @@ namespace Unity.Netcode.RuntimeTests
     /// can never be less than the tick latency. Deriving the render time from LocalTime eats into that margin by
     /// however far the two clocks are apart, and can push the target past ServerTime entirely.
     /// </remarks>
-    [TestFixture(HostOrServer.Host, NetworkTransform.InterpolationTypes.Lerp)]
-    [TestFixture(HostOrServer.Host, NetworkTransform.InterpolationTypes.SmoothDampening)]
+    [TestFixture(NetworkTransform.InterpolationTypes.Lerp)]
+    [TestFixture(NetworkTransform.InterpolationTypes.SmoothDampening)]
     internal class NetworkTransformInterpolationRenderTimeTests : IntegrationTestWithApproximation
     {
         protected override int NumberOfClients => 1;
@@ -47,17 +46,10 @@ namespace Unity.Netcode.RuntimeTests
         private NetworkManager m_AuthorityNetworkManager;
         private NetworkTransform m_AuthorityInstance;
         private Vector3 m_Direction;
-        private int m_TickCount;
 
-        public NetworkTransformInterpolationRenderTimeTests(HostOrServer hostOrServer, NetworkTransform.InterpolationTypes interpolationType) : base(hostOrServer)
+        public NetworkTransformInterpolationRenderTimeTests(NetworkTransform.InterpolationTypes interpolationType)
         {
             m_InterpolationType = interpolationType;
-        }
-
-        // TODO: [CmbServiceTests] ServerTime's meaning under a CMB service session has not been verified.
-        protected override bool UseCMBService()
-        {
-            return false;
         }
 
         protected override void OnServerAndClientsCreated()
@@ -86,41 +78,7 @@ namespace Unity.Netcode.RuntimeTests
         /// </summary>
         private void OnNetworkTick()
         {
-            m_TickCount++;
             m_AuthorityInstance.transform.position += m_Direction * k_DistancePerTick;
-        }
-
-        private bool AllClientsSpawnedInstance()
-        {
-            foreach (var networkManager in m_NetworkManagers)
-            {
-                if (networkManager == m_AuthorityNetworkManager)
-                {
-                    continue;
-                }
-
-                if (!networkManager.SpawnManager.SpawnedObjects.ContainsKey(m_AuthorityInstance.NetworkObject.NetworkObjectId))
-                {
-                    return false;
-                }
-            }
-            return true;
-        }
-
-        private List<NetworkTransform> GetNonAuthorityInstances()
-        {
-            var instances = new List<NetworkTransform>();
-            foreach (var networkManager in m_NetworkManagers)
-            {
-                if (networkManager == m_AuthorityNetworkManager)
-                {
-                    continue;
-                }
-
-                var spawnedObject = networkManager.SpawnManager.SpawnedObjects[m_AuthorityInstance.NetworkObject.NetworkObjectId];
-                instances.Add(spawnedObject.GetComponent<NetworkTransform>());
-            }
-            return instances;
         }
 
         [UnityTest]
@@ -129,96 +87,61 @@ namespace Unity.Netcode.RuntimeTests
             m_AuthorityNetworkManager = GetAuthorityNetworkManager();
             m_AuthorityInstance = SpawnObject(m_TestPrefab, m_AuthorityNetworkManager).GetComponent<NetworkTransform>();
 
-            yield return WaitForConditionOrTimeOut(AllClientsSpawnedInstance);
+            yield return WaitForSpawnedOnAllOrTimeOut(m_AuthorityInstance.NetworkObject);
             AssertOnTimeout($"Not all clients spawned {m_AuthorityInstance.name}!");
 
-            var nonAuthorityInstances = GetNonAuthorityInstances();
-            Assert.IsNotEmpty(nonAuthorityInstances, "There were no non-authority instances to measure!");
+            var nonAuthority = GetNonAuthorityNetworkManager();
+            var nonAuthorityInstance = nonAuthority.SpawnManager.SpawnedObjects[m_AuthorityInstance.NetworkObject.NetworkObjectId].GetComponent<NetworkTransform>();
 
             // Separate the two clocks by a known amount so that which one the render time is derived from is
             // actually distinguishable.
-            foreach (var instance in nonAuthorityInstances)
-            {
-                var networkManager = instance.NetworkManager;
-                networkManager.NetworkTimeSystem.LocalBufferSec = k_LocalBufferTicks * GetTickInterval(networkManager);
-            }
+            nonAuthority.NetworkTimeSystem.LocalBufferSec = k_LocalBufferTicks * GetTickInterval(nonAuthority);
 
             // Start continuous motion on the authority.
             m_Direction = GetRandomVector3(-10, 10).normalized;
-            m_TickCount = 0;
             m_AuthorityNetworkManager.NetworkTickSystem.Tick += OnNetworkTick;
 
             // The offset only moves when the client next receives a time sync, so wait for the separation to
             // actually take hold rather than assuming it has.
-            yield return WaitForConditionOrTimeOut(() =>
-            {
-                foreach (var instance in nonAuthorityInstances)
-                {
-                    if (GetClockLeadInTicks(instance.NetworkManager) < k_RequiredLeadTicks)
-                    {
-                        return false;
-                    }
-                }
-                return true;
-            });
-            AssertOnTimeout($"The client clocks never separated by {k_RequiredLeadTicks} ticks, so this test " +
-                $"cannot tell the two clocks apart and would pass regardless of which one is used.");
+            yield return WaitForConditionOrTimeOut(() => GetClockLeadInTicks(nonAuthority) >= k_RequiredLeadTicks);
+            AssertOnTimeout($"The nonAuthority clock never fell {k_RequiredLeadTicks} ticks behind, so this test " +
+                "cannot tell the two clocks apart and would pass regardless of which one is used.");
 
             // Let the interpolator settle at the new separation before measuring.
-            var warmUpTarget = m_TickCount + k_WarmUpTicks;
-            yield return WaitForConditionOrTimeOut(() => m_TickCount >= warmUpTarget);
-            AssertOnTimeout("Timed out waiting for the authority to keep moving!");
+            yield return WaitForTicks(m_AuthorityNetworkManager, k_WarmUpTicks);
 
             // Sample how far behind ServerTime the state being interpolated towards was sent.
-            var totalTargetLagTicks = new Dictionary<NetworkTransform, double>();
-            var totalBuffered = new Dictionary<NetworkTransform, int>();
-            var samples = new Dictionary<NetworkTransform, int>();
-            foreach (var instance in nonAuthorityInstances)
-            {
-                totalTargetLagTicks.Add(instance, 0.0d);
-                totalBuffered.Add(instance, 0);
-                samples.Add(instance, 0);
-            }
-
+            var interpolator = nonAuthorityInstance.GetPositionInterpolator();
+            var totalTargetLagTicks = 0.0d;
+            var totalBuffered = 0;
+            var samples = 0;
             for (int frame = 0; frame < k_SampledFrames; frame++)
             {
-                foreach (var instance in nonAuthorityInstances)
+                if (interpolator.InterpolateState.Target.HasValue)
                 {
-                    var interpolator = instance.GetPositionInterpolator();
-                    if (!interpolator.InterpolateState.Target.HasValue)
-                    {
-                        continue;
-                    }
-
-                    var networkManager = instance.NetworkManager;
-                    var targetLag = networkManager.ServerTime.Time - interpolator.InterpolateState.Target.Value.TimeSent;
-                    totalTargetLagTicks[instance] += targetLag / GetTickInterval(networkManager);
-                    totalBuffered[instance] += interpolator.m_BufferQueue.Count;
-                    samples[instance]++;
+                    var targetLag = nonAuthority.ServerTime.Time - interpolator.InterpolateState.Target.Value.TimeSent;
+                    totalTargetLagTicks += targetLag / GetTickInterval(nonAuthority);
+                    totalBuffered += interpolator.m_BufferQueue.Count;
+                    samples++;
                 }
                 yield return null;
             }
 
             m_AuthorityNetworkManager.NetworkTickSystem.Tick -= OnNetworkTick;
 
-            foreach (var instance in nonAuthorityInstances)
-            {
-                Assert.Greater(samples[instance], 0, $"{instance.name} never had a state to interpolate towards!");
+            Assert.Greater(samples, 0, $"{nonAuthorityInstance.name} never had a state to interpolate towards!");
 
-                var networkManager = instance.NetworkManager;
-                var meanTargetLagTicks = totalTargetLagTicks[instance] / samples[instance];
-                var meanBuffered = totalBuffered[instance] / (float)samples[instance];
-                var tickLatency = networkManager.NetworkTimeSystem.TickLatency;
+            var meanTargetLagTicks = totalTargetLagTicks / samples;
+            var meanBuffered = totalBuffered / (float)samples;
+            var tickLatency = nonAuthority.NetworkTimeSystem.TickLatency;
 
-                // Anything less than the tick latency means the render time came from a clock that leads the one
-                // the states are stamped on.
-                Assert.GreaterOrEqual(meanTargetLagTicks, tickLatency,
-                    $"[{m_InterpolationType}] {instance.name} was interpolating towards a state sent " +
-                    $"{meanTargetLagTicks:F3} ticks behind the server clock, but the render time is the server " +
-                    $"clock minus a tick latency of {tickLatency}, so it should never be less than that. " +
-                    $"(clock lead {GetClockLeadInTicks(networkManager):F3} ticks, mean buffered {meanBuffered:F3}). " +
-                    $"The render time is being derived from a clock that leads the one state updates are stamped on.");
-            }
+            // Anything less than the tick latency means the render time came from a clock that leads the one
+            // the states are stamped on.
+            Assert.GreaterOrEqual(meanTargetLagTicks, tickLatency,
+                $"[{m_InterpolationType}] {nonAuthorityInstance.name} was interpolating towards a state sent " +
+                $"{meanTargetLagTicks:F3} ticks behind the server clock, but the render time is the server " +
+                $"clock minus a tick latency of {tickLatency}, so it should never be less than that. " +
+                $"(clock lead {GetClockLeadInTicks(nonAuthority):F3} ticks, mean buffered {meanBuffered:F3})");
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformInterpolationRenderTimeTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformInterpolationRenderTimeTests.cs
@@ -1,0 +1,239 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Unity.Netcode.Components;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    /// <summary>
+    /// Validates that the render time a non-authority instance interpolates towards is derived from the same
+    /// clock that the state updates it is interpolating between are stamped on.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="NetworkTransform"/> state's SentTime is derived from its NetworkTick, which is a server
+    /// tick, so the render time has to be measured from ServerTime. Measuring it from LocalTime mixes two
+    /// clocks: LocalTime leads ServerTime, so subtracting the tick latency from LocalTime lands the render time
+    /// back at approximately ServerTime rather than a whole tick latency behind it. The interpolator is then
+    /// asked to render a point in time at (or ahead of) the newest state that can possibly exist, so it has
+    /// nothing left to interpolate towards.
+    ///
+    /// What this test measures is how far behind ServerTime the state currently being interpolated towards was
+    /// sent. Because the target is selected against the render time, this has to be at least the tick latency:
+    /// the render time is ServerTime minus the tick latency, and only states sent at or before the render time
+    /// are eligible. Deriving the render time from LocalTime instead eats into that margin by however far the
+    /// two clocks are apart, and can push the target past ServerTime entirely (a negative value below, meaning
+    /// the interpolator is chasing a state that the server clock says has not happened yet).
+    /// </remarks>
+    [TestFixture(HostOrServer.Host, NetworkTransform.InterpolationTypes.Lerp)]
+    [TestFixture(HostOrServer.Host, NetworkTransform.InterpolationTypes.SmoothDampening)]
+    internal class NetworkTransformInterpolationRenderTimeTests : IntegrationTestWithApproximation
+    {
+        protected override int NumberOfClients => 1;
+
+        // How far LocalTime is pushed ahead of ServerTime, in ticks. An in-process integration test has
+        // effectively no round trip time and the separation between the two clocks is
+        // (half RTT + LocalBufferSec + ServerBufferSec), so without widening the local buffer the two clocks
+        // sit close enough together that which one is used barely shows. This is deliberately large enough to
+        // exceed NetworkTimeSystem's hard reset threshold (0.2s) so the offset snaps rather than converging at
+        // the default adjustment ratio of 0.01s per second, which would take over ten seconds.
+        private const int k_LocalBufferTicks = 12;
+
+        // The separation the clocks must actually reach before any measurement is taken.
+        private const double k_RequiredLeadTicks = 8.0d;
+
+        // Ticks of authority motion after the clocks have separated, so the interpolator reaches steady state.
+        private const int k_WarmUpTicks = 20;
+
+        // The number of rendered frames sampled once the warm up has completed.
+        private const int k_SampledFrames = 90;
+
+        // The distance the authority moves each tick. Large enough that every tick produces a state update
+        // rather than being filtered out by the position threshold.
+        private const float k_DistancePerTick = 1.37f;
+
+        private readonly NetworkTransform.InterpolationTypes m_InterpolationType;
+
+        private GameObject m_TestPrefab;
+        private NetworkManager m_AuthorityNetworkManager;
+        private NetworkTransform m_AuthorityInstance;
+        private Vector3 m_Direction;
+        private int m_TickCount;
+
+        public NetworkTransformInterpolationRenderTimeTests(HostOrServer hostOrServer, NetworkTransform.InterpolationTypes interpolationType) : base(hostOrServer)
+        {
+            m_InterpolationType = interpolationType;
+        }
+
+        // TODO: [CmbServiceTests] ServerTime's meaning under a CMB service session has not been verified.
+        protected override bool UseCMBService()
+        {
+            return false;
+        }
+
+        protected override void OnServerAndClientsCreated()
+        {
+            m_TestPrefab = CreateNetworkObjectPrefab("RenderTimeTestObj");
+            var networkTransform = m_TestPrefab.AddComponent<NetworkTransform>();
+            networkTransform.PositionInterpolationType = m_InterpolationType;
+            base.OnServerAndClientsCreated();
+        }
+
+        private static double GetTickInterval(NetworkManager networkManager)
+        {
+            return 1.0d / networkManager.NetworkTickSystem.TickRate;
+        }
+
+        /// <summary>
+        /// How far LocalTime currently leads ServerTime, expressed in ticks.
+        /// </summary>
+        private static double GetClockLeadInTicks(NetworkManager networkManager)
+        {
+            return (networkManager.LocalTime.Time - networkManager.ServerTime.Time) / GetTickInterval(networkManager);
+        }
+
+        /// <summary>
+        /// Moves the authority instance once per tick so that a state update is generated every tick.
+        /// </summary>
+        private void OnNetworkTick()
+        {
+            m_TickCount++;
+            m_AuthorityInstance.transform.position += m_Direction * k_DistancePerTick;
+        }
+
+        private bool AllClientsSpawnedInstance()
+        {
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                if (networkManager == m_AuthorityNetworkManager)
+                {
+                    continue;
+                }
+
+                if (!networkManager.SpawnManager.SpawnedObjects.ContainsKey(m_AuthorityInstance.NetworkObject.NetworkObjectId))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private List<NetworkTransform> GetNonAuthorityInstances()
+        {
+            var instances = new List<NetworkTransform>();
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                if (networkManager == m_AuthorityNetworkManager)
+                {
+                    continue;
+                }
+
+                var spawnedObject = networkManager.SpawnManager.SpawnedObjects[m_AuthorityInstance.NetworkObject.NetworkObjectId];
+                instances.Add(spawnedObject.GetComponent<NetworkTransform>());
+            }
+            return instances;
+        }
+
+        [UnityTest]
+        public IEnumerator RenderTimeTrailsTheServerClock()
+        {
+            m_AuthorityNetworkManager = GetAuthorityNetworkManager();
+            m_AuthorityInstance = SpawnObject(m_TestPrefab, m_AuthorityNetworkManager).GetComponent<NetworkTransform>();
+
+            yield return WaitForConditionOrTimeOut(AllClientsSpawnedInstance);
+            AssertOnTimeout($"Not all clients spawned {m_AuthorityInstance.name}!");
+
+            var nonAuthorityInstances = GetNonAuthorityInstances();
+            Assert.IsNotEmpty(nonAuthorityInstances, "There were no non-authority instances to measure!");
+
+            // Separate the two clocks by a known amount so that which one the render time is derived from is
+            // actually distinguishable.
+            foreach (var instance in nonAuthorityInstances)
+            {
+                var networkManager = instance.NetworkManager;
+                networkManager.NetworkTimeSystem.LocalBufferSec = k_LocalBufferTicks * GetTickInterval(networkManager);
+            }
+
+            // Start continuous motion on the authority.
+            m_Direction = GetRandomVector3(-10, 10).normalized;
+            m_TickCount = 0;
+            m_AuthorityNetworkManager.NetworkTickSystem.Tick += OnNetworkTick;
+
+            // The offset only moves when the client next receives a time sync, so wait for the separation to
+            // actually take hold rather than assuming it has.
+            yield return WaitForConditionOrTimeOut(() =>
+            {
+                foreach (var instance in nonAuthorityInstances)
+                {
+                    if (GetClockLeadInTicks(instance.NetworkManager) < k_RequiredLeadTicks)
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            });
+            AssertOnTimeout($"The client clocks never separated by {k_RequiredLeadTicks} ticks, so this test " +
+                $"cannot tell the two clocks apart and would pass regardless of which one is used.");
+
+            // Let the interpolator settle at the new separation before measuring.
+            var warmUpTarget = m_TickCount + k_WarmUpTicks;
+            yield return WaitForConditionOrTimeOut(() => m_TickCount >= warmUpTarget);
+            AssertOnTimeout("Timed out waiting for the authority to keep moving!");
+
+            // Sample how far behind ServerTime the state being interpolated towards was sent.
+            var totalTargetLagTicks = new Dictionary<NetworkTransform, double>();
+            var totalBuffered = new Dictionary<NetworkTransform, int>();
+            var samples = new Dictionary<NetworkTransform, int>();
+            foreach (var instance in nonAuthorityInstances)
+            {
+                totalTargetLagTicks.Add(instance, 0.0d);
+                totalBuffered.Add(instance, 0);
+                samples.Add(instance, 0);
+            }
+
+            for (int frame = 0; frame < k_SampledFrames; frame++)
+            {
+                foreach (var instance in nonAuthorityInstances)
+                {
+                    var interpolator = instance.GetPositionInterpolator();
+                    if (!interpolator.InterpolateState.Target.HasValue)
+                    {
+                        continue;
+                    }
+
+                    var networkManager = instance.NetworkManager;
+                    var targetLag = networkManager.ServerTime.Time - interpolator.InterpolateState.Target.Value.TimeSent;
+                    totalTargetLagTicks[instance] += targetLag / GetTickInterval(networkManager);
+                    totalBuffered[instance] += interpolator.m_BufferQueue.Count;
+                    samples[instance]++;
+                }
+                yield return null;
+            }
+
+            m_AuthorityNetworkManager.NetworkTickSystem.Tick -= OnNetworkTick;
+
+            foreach (var instance in nonAuthorityInstances)
+            {
+                Assert.Greater(samples[instance], 0, $"{instance.name} never had a state to interpolate towards!");
+
+                var networkManager = instance.NetworkManager;
+                var meanTargetLagTicks = totalTargetLagTicks[instance] / samples[instance];
+                var meanBuffered = totalBuffered[instance] / (float)samples[instance];
+                var tickLatency = networkManager.NetworkTimeSystem.TickLatency;
+
+                // Only states sent at or before the render time are eligible to be interpolated towards, and the
+                // render time is the server clock minus the tick latency, so the target can never be newer than
+                // that. Anything less means the render time was taken from a clock that runs ahead of the one
+                // the states are stamped on.
+                Assert.GreaterOrEqual(meanTargetLagTicks, tickLatency,
+                    $"[{m_InterpolationType}] {instance.name} was interpolating towards a state sent " +
+                    $"{meanTargetLagTicks:F3} ticks behind the server clock, but the render time is the server " +
+                    $"clock minus a tick latency of {tickLatency}, so it should never be less than that. " +
+                    $"(clock lead {GetClockLeadInTicks(networkManager):F3} ticks, mean buffered {meanBuffered:F3}). " +
+                    $"The render time is being derived from a clock that leads the one state updates are stamped on.");
+            }
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformInterpolationRenderTimeTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformInterpolationRenderTimeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: acef3f08e52a1e143bbffdddb16cdfc5

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTickLatencyTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTickLatencyTests.cs
@@ -43,56 +43,38 @@ namespace Unity.Netcode.RuntimeTests
             return base.OnTearDown();
         }
 
-        private static float GetExpectedLatencyInSeconds(NetworkManager networkManager)
-        {
-            var ticksBehind = networkManager.NetworkTimeSystem.TickLatency + NetworkTransform.InterpolationBufferTickOffset;
-            return (float)(ticksBehind * networkManager.ServerTime.FixedDeltaTimeAsDouble);
-        }
-
         [UnityTest]
-        public IEnumerator GetTickLatencyInSecondsReturnsADuration()
+        public IEnumerator GetTickLatencyInSecondsReturnsADurationNotATimestamp()
         {
-            var client = m_ClientNetworkManagers[0];
+            var client = GetNonAuthorityNetworkManager();
+            var tickInterval = (float)client.ServerTime.FixedDeltaTimeAsDouble;
 
-            // Sample repeatedly while the session clock advances. A duration tracks the tick latency, where an
-            // absolute timestamp would climb by roughly one second per second.
-            //
-            // NetworkTimeSystem.TickLatency is adaptive and can legitimately change mid-run, so the value is
-            // only held to being unchanged across samples where the tick latency itself did not change.
+            // A timestamp climbs by roughly a second per second, so sample while the session clock advances
+            // and hold the value to only moving when the tick latency it is derived from moves. That latency
+            // is adaptive and can legitimately change mid-run.
             var previousTicksBehind = -1;
             var previousValue = 0f;
             for (int i = 0; i < k_Samples; i++)
             {
                 var ticksBehind = client.NetworkTimeSystem.TickLatency + NetworkTransform.InterpolationBufferTickOffset;
-                var expected = GetExpectedLatencyInSeconds(client);
-                var actual = NetworkTransform.GetTickLatencyInSeconds(client);
+                var latency = NetworkTransform.GetTickLatencyInSeconds(client);
 
-                Assert.AreEqual(expected, actual, k_Tolerance,
-                    $"Expected the tick latency to be {expected}s but it was {actual}s.");
-
+                Assert.Greater(latency, 0f, "A latency of zero or less is not a duration this can be measured against.");
                 if (ticksBehind == previousTicksBehind)
                 {
-                    Assert.AreEqual(previousValue, actual, k_Tolerance,
-                        $"The reported latency moved from {previousValue}s to {actual}s while the tick latency " +
+                    Assert.AreEqual(previousValue, latency, k_Tolerance,
+                        $"The reported latency moved from {previousValue}s to {latency}s while the tick latency " +
                         $"stayed at {ticksBehind} ticks, so it is tracking elapsed time rather than latency.");
                 }
 
                 previousTicksBehind = ticksBehind;
-                previousValue = actual;
+                previousValue = latency;
                 yield return null;
             }
-        }
-
-        [UnityTest]
-        public IEnumerator GetTickLatencyInSecondsTracksTheBufferTickOffset()
-        {
-            var client = m_ClientNetworkManagers[0];
-            var tickInterval = (float)client.ServerTime.FixedDeltaTimeAsDouble;
-
-            var latencyBefore = client.NetworkTimeSystem.TickLatency;
-            var before = NetworkTransform.GetTickLatencyInSeconds(client);
 
             // Buffering more ticks has to lengthen the reported duration by exactly those ticks.
+            var latencyBefore = client.NetworkTimeSystem.TickLatency;
+            var before = NetworkTransform.GetTickLatencyInSeconds(client);
             NetworkTransform.InterpolationBufferTickOffset = m_OriginalBufferTickOffset + k_AddedBufferTicks;
             yield return null;
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTickLatencyTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTickLatencyTests.cs
@@ -54,22 +54,33 @@ namespace Unity.Netcode.RuntimeTests
         {
             var client = m_ClientNetworkManagers[0];
 
-            // Sample repeatedly while the session clock advances. A duration tracks the tick latency and stays
-            // put, where an absolute timestamp would climb by roughly one second per second.
-            var firstSample = NetworkTransform.GetTickLatencyInSeconds(client);
+            // Sample repeatedly while the session clock advances. A duration tracks the tick latency, where an
+            // absolute timestamp would climb by roughly one second per second.
+            //
+            // NetworkTimeSystem.TickLatency is adaptive and can legitimately change mid-run, so the value is
+            // only held to being unchanged across samples where the tick latency itself did not change.
+            var previousTicksBehind = -1;
+            var previousValue = 0f;
             for (int i = 0; i < k_Samples; i++)
             {
+                var ticksBehind = client.NetworkTimeSystem.TickLatency + NetworkTransform.InterpolationBufferTickOffset;
                 var expected = GetExpectedLatencyInSeconds(client);
                 var actual = NetworkTransform.GetTickLatencyInSeconds(client);
+
                 Assert.AreEqual(expected, actual, k_Tolerance,
                     $"Expected the tick latency to be {expected}s but it was {actual}s.");
+
+                if (ticksBehind == previousTicksBehind)
+                {
+                    Assert.AreEqual(previousValue, actual, k_Tolerance,
+                        $"The reported latency moved from {previousValue}s to {actual}s while the tick latency " +
+                        $"stayed at {ticksBehind} ticks, so it is tracking elapsed time rather than latency.");
+                }
+
+                previousTicksBehind = ticksBehind;
+                previousValue = actual;
                 yield return null;
             }
-
-            var lastSample = NetworkTransform.GetTickLatencyInSeconds(client);
-            Assert.AreEqual(firstSample, lastSample, k_Tolerance,
-                $"The tick latency changed from {firstSample}s to {lastSample}s while the session ran without " +
-                $"the tick latency itself changing, so it is tracking elapsed time rather than latency.");
         }
 
         [UnityTest]
@@ -78,18 +89,23 @@ namespace Unity.Netcode.RuntimeTests
             var client = m_ClientNetworkManagers[0];
             var tickInterval = (float)client.ServerTime.FixedDeltaTimeAsDouble;
 
+            var latencyBefore = client.NetworkTimeSystem.TickLatency;
             var before = NetworkTransform.GetTickLatencyInSeconds(client);
 
             // Buffering more ticks has to lengthen the reported duration by exactly those ticks.
             NetworkTransform.InterpolationBufferTickOffset = m_OriginalBufferTickOffset + k_AddedBufferTicks;
             yield return null;
 
+            var latencyAfter = client.NetworkTimeSystem.TickLatency;
             var after = NetworkTransform.GetTickLatencyInSeconds(client);
-            var expectedIncrease = k_AddedBufferTicks * tickInterval;
+
+            // The adaptive tick latency may also have moved in between, so only the buffering is held to an
+            // exact figure.
+            var expectedIncrease = (k_AddedBufferTicks + (latencyAfter - latencyBefore)) * tickInterval;
             Assert.AreEqual(expectedIncrease, after - before, k_Tolerance,
                 $"Adding {k_AddedBufferTicks} ticks of buffering changed the reported latency by " +
                 $"{after - before}s when a tick is {tickInterval}s, so it should have changed by " +
-                $"{expectedIncrease}s.");
+                $"{expectedIncrease}s (tick latency went from {latencyBefore} to {latencyAfter}).");
         }
     }
 }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTickLatencyTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTickLatencyTests.cs
@@ -1,0 +1,96 @@
+using System.Collections;
+using NUnit.Framework;
+using Unity.Netcode.Components;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    /// <summary>
+    /// Validates that <see cref="NetworkTransform.GetTickLatencyInSeconds()"/> returns what it is documented to
+    /// return: the tick latency as a duration in seconds.
+    /// </summary>
+    /// <remarks>
+    /// It previously returned <c>TimeTicksAgo(...).Time</c>, which is an absolute network timestamp rather than a
+    /// duration, so the value grew for as long as the session ran.
+    /// </remarks>
+    internal class NetworkTransformTickLatencyTests : NetcodeIntegrationTest
+    {
+        protected override int NumberOfClients => 1;
+
+        // Ticks of additional buffering applied part way through the test to confirm the returned duration
+        // tracks the tick latency it is derived from.
+        private const int k_AddedBufferTicks = 3;
+
+        // Seconds of tolerance when comparing against the expected duration.
+        private const float k_Tolerance = 0.0005f;
+
+        // The number of samples taken while the session runs, to confirm the value does not drift with time.
+        private const int k_Samples = 30;
+
+        private int m_OriginalBufferTickOffset;
+
+        protected override IEnumerator OnSetup()
+        {
+            m_OriginalBufferTickOffset = NetworkTransform.InterpolationBufferTickOffset;
+            return base.OnSetup();
+        }
+
+        protected override IEnumerator OnTearDown()
+        {
+            // This is static, so leaving it modified would leak into every test that runs afterwards.
+            NetworkTransform.InterpolationBufferTickOffset = m_OriginalBufferTickOffset;
+            return base.OnTearDown();
+        }
+
+        private static float GetExpectedLatencyInSeconds(NetworkManager networkManager)
+        {
+            var ticksBehind = networkManager.NetworkTimeSystem.TickLatency + NetworkTransform.InterpolationBufferTickOffset;
+            return (float)(ticksBehind * networkManager.ServerTime.FixedDeltaTimeAsDouble);
+        }
+
+        [UnityTest]
+        public IEnumerator GetTickLatencyInSecondsReturnsADuration()
+        {
+            var client = m_ClientNetworkManagers[0];
+
+            // Sample repeatedly while the session clock advances. A duration tracks the tick latency and stays
+            // put, where an absolute timestamp would climb by roughly one second per second.
+            var firstSample = NetworkTransform.GetTickLatencyInSeconds(client);
+            for (int i = 0; i < k_Samples; i++)
+            {
+                var expected = GetExpectedLatencyInSeconds(client);
+                var actual = NetworkTransform.GetTickLatencyInSeconds(client);
+                Assert.AreEqual(expected, actual, k_Tolerance,
+                    $"Expected the tick latency to be {expected}s but it was {actual}s.");
+                yield return null;
+            }
+
+            var lastSample = NetworkTransform.GetTickLatencyInSeconds(client);
+            Assert.AreEqual(firstSample, lastSample, k_Tolerance,
+                $"The tick latency changed from {firstSample}s to {lastSample}s while the session ran without " +
+                $"the tick latency itself changing, so it is tracking elapsed time rather than latency.");
+        }
+
+        [UnityTest]
+        public IEnumerator GetTickLatencyInSecondsTracksTheBufferTickOffset()
+        {
+            var client = m_ClientNetworkManagers[0];
+            var tickInterval = (float)client.ServerTime.FixedDeltaTimeAsDouble;
+
+            var before = NetworkTransform.GetTickLatencyInSeconds(client);
+
+            // Buffering more ticks has to lengthen the reported duration by exactly those ticks.
+            NetworkTransform.InterpolationBufferTickOffset = m_OriginalBufferTickOffset + k_AddedBufferTicks;
+            yield return null;
+
+            var after = NetworkTransform.GetTickLatencyInSeconds(client);
+            var expectedIncrease = k_AddedBufferTicks * tickInterval;
+            Assert.AreEqual(expectedIncrease, after - before, k_Tolerance,
+                $"Adding {k_AddedBufferTicks} ticks of buffering changed the reported latency by " +
+                $"{after - before}s when a tick is {tickInterval}s, so it should have changed by " +
+                $"{expectedIncrease}s.");
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTickLatencyTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTickLatencyTests.cs
@@ -2,7 +2,6 @@ using System.Collections;
 using NUnit.Framework;
 using Unity.Netcode.Components;
 using Unity.Netcode.TestHelpers.Runtime;
-using UnityEngine;
 using UnityEngine.TestTools;
 
 namespace Unity.Netcode.RuntimeTests

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTickLatencyTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformTickLatencyTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 36f3fd2271d60504cbf04455d7ad3908


### PR DESCRIPTION
## Purpose of this PR

A `NetworkTransform` state's `SentTime` comes from its `NetworkTick` — a **server** tick — but the render time the interpolators were given was derived from `LocalTime`. Since `LocalTime` already leads `ServerTime` by roughly the tick latency, subtracting the tick latency from it put the render time back at approximately `ServerTime` instead of a buffer behind it. Clients were therefore asked to render a point in time at or ahead of the newest state that could exist, leaving the interpolator with nothing to interpolate towards.

Now derived from `ServerTime`, which also matches the rest of the component — `NetworkTransform` already resets its interpolators using `ServerTime`.

**The tradeoff reviewers should weigh:** non-authority instances now sit a full tick latency behind rather than approximately at the present. That is roughly 75ms of additional visual latency, in exchange for actual interpolation instead of snapping between state updates. No-op on host/server, where both clocks are the same.

`GetTickLatencyInSeconds` now returns the actual tick latency in seconds.

### Jira ticket

_TODO: add ticket_

### Changelog

- Fixed: Issue where `NetworkTransform` interpolated towards a point in time taken from the local clock rather than the server clock that state updates are stamped on, which starved the interpolator on clients and reduced interpolation to snapping between state updates.
- Fixed: Issue where `NetworkTransform.GetTickLatencyInSeconds` returned an absolute network timestamp that grew for as long as the session ran, rather than the tick latency as a duration in seconds that it is documented to return.

## Documentation

- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)

New integration test measures how far behind `ServerTime` the state being interpolated towards was sent. That value can never be less than the tick latency, since the render time is `ServerTime` minus the tick latency and only states sent at or before it are eligible.

Validated in both directions on `develop-2.0.0`: without the fix both fixtures fail, reporting the target as **−0.899** and **−1.059** ticks — the interpolator chasing a state the server clock says has not happened yet. With the fix both pass. The full `NetworkTransform` playmode suite is green (3942/3942).

The test widens the client's local time buffer before measuring, because an in-process test has no round trip time to separate the two clocks and would otherwise pass regardless of which one is used. It waits for that separation to take hold and fails if it never does, so it cannot silently become a no-op.

For release playtest, the thing to look at is client-side smoothness of moving networked objects, and whether the added latency is acceptable.

### Functional Testing

_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [x] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [x] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

## Up-port
Up-port: #4135
Required. 

## Backports

Not needed.