### PR TITLE
Fix/networktransform interpolation render time up port

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -19,26 +19,21 @@ Additional documentation and release notes are available at [Multiplayer Documen
   - `Unity.Netcode.Editor.PackageChecker` → `Unity.Netcode.GameObjects.Editor.PackageChecker`
   - `Unity.Netcode.Editor.Tests` → `Unity.Netcode.GameObjects.Editor.Tests`
 
-
-
 ### Deprecated
-
 
 ### Removed
 
-
 ### Fixed
 
+- Issue where non-authority `NetworkTransform` instances derived their interpolation time from the local clock instead of the server clock that state updates are stamped on, which starved the interpolator and reduced interpolation to snapping between state updates. (#TBD)
+- Issue where `NetworkTransform.GetTickLatencyInSeconds` returned a time derived from the local clock, which did not match the time the interpolators actually use. (#TBD)
 - Issue with not being able to spawn initially disabled in-scene placed objects. (#4093)
 - Issue with pre-instantiated network prefab instances being marked as in-scene placed. Now pre-instantiated network prefabs are dynamically spawned. (#4093)
 - Issue where a user could spawn runtime created `NetworkObject` that has a GlobalObjectIdHash of zero. These are not valid instances and will no longer be allowed to spawn. (#4093)
 
-
 ### Security
 
-
 ### Obsolete
-
 
 ## [2.13.1] - 2026-07-19
 

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
@@ -4259,26 +4259,12 @@ namespace Unity.Netcode.Components
         // Non-Authority
         private void UpdateInterpolation()
         {
-            // Use the server time, because that is the clock the measurements being interpolated between are
-            // stamped on: a state's SentTime is derived from its NetworkTick, which is a server tick.
-            //
-            // Deriving the render time from LocalTime instead mixes two clocks. LocalTime leads ServerTime by
-            // roughly the tick latency, so subtracting the tick latency from it lands the render time back at
-            // (approximately) ServerTime rather than behind it. "Approximately" is the problem: the lead is
-            // fractional while the subtraction is a whole number of ticks, and a state's SentTime is floored to
-            // a tick boundary on top of that. The render time therefore ends up at or slightly ahead of the
-            // newest state that can exist, leaving the interpolator with nothing to interpolate towards. A
-            // measured session had the render time ahead of ServerTime on 100% of frames, with the interpolator
-            // never holding more than one measurement.
-            //
-            // Measuring from ServerTime instead makes the offset the whole tick latency rather than whatever is
-            // left of it, which is self correcting: as the round trip time grows, NetworkTimeSystem.TickLatency
-            // grows and the render time moves further back with it.
-            //
-            // Note this is a no-op on a host or server, where LocalTime and ServerTime are the same.
-            // TODO-JIRA-TICKET:
-            // Confirm the distributed authority case. Authority instances interpolate nothing, so this should
-            // not reach them, but ServerTime's meaning under a CMB service session should be verified.
+            // Use the server time, since that is the clock the states being interpolated between are stamped on
+            // (a state's SentTime is derived from its NetworkTick). Deriving the render time from LocalTime
+            // subtracts the tick latency from a clock that already leads ServerTime by roughly that much, which
+            // leaves the render time at or ahead of the newest state that can exist and starves the interpolator.
+            // Measuring from ServerTime is also self correcting, as the tick latency grows with the round trip
+            // time. This is a no-op on a host or server, where both clocks are the same.
             var timeSystem = m_CachedNetworkManager.ServerTime;
             var currentTime = timeSystem.Time;
 #if COM_UNITY_MODULES_PHYSICS || COM_UNITY_MODULES_PHYSICS2D

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
@@ -4259,14 +4259,27 @@ namespace Unity.Netcode.Components
         // Non-Authority
         private void UpdateInterpolation()
         {
-            // Use the local time because:
-            // Client-Server:
-            // Local time is server time on a host or server.
-            // Local time on clients takes latency into consideration.
-            // Distributed authority:
-            // Local time is used by the authority.
-            // Local time on non-authority takes latency into consid]eration.
-            var timeSystem = m_CachedNetworkManager.LocalTime;
+            // Use the server time, because that is the clock the measurements being interpolated between are
+            // stamped on: a state's SentTime is derived from its NetworkTick, which is a server tick.
+            //
+            // Deriving the render time from LocalTime instead mixes two clocks. LocalTime leads ServerTime by
+            // roughly the tick latency, so subtracting the tick latency from it lands the render time back at
+            // (approximately) ServerTime rather than behind it. "Approximately" is the problem: the lead is
+            // fractional while the subtraction is a whole number of ticks, and a state's SentTime is floored to
+            // a tick boundary on top of that. The render time therefore ends up at or slightly ahead of the
+            // newest state that can exist, leaving the interpolator with nothing to interpolate towards. A
+            // measured session had the render time ahead of ServerTime on 100% of frames, with the interpolator
+            // never holding more than one measurement.
+            //
+            // Measuring from ServerTime instead makes the offset the whole tick latency rather than whatever is
+            // left of it, which is self correcting: as the round trip time grows, NetworkTimeSystem.TickLatency
+            // grows and the render time moves further back with it.
+            //
+            // Note this is a no-op on a host or server, where LocalTime and ServerTime are the same.
+            // TODO-JIRA-TICKET:
+            // Confirm the distributed authority case. Authority instances interpolate nothing, so this should
+            // not reach them, but ServerTime's meaning under a CMB service session should be verified.
+            var timeSystem = m_CachedNetworkManager.ServerTime;
             var currentTime = timeSystem.Time;
 #if COM_UNITY_MODULES_PHYSICS || COM_UNITY_MODULES_PHYSICS2D
             var cachedDeltaTime = m_UseRigidbodyForMotion ? m_CachedNetworkManager.RealTimeProvider.FixedDeltaTime : m_CachedNetworkManager.RealTimeProvider.DeltaTime;
@@ -4730,7 +4743,7 @@ namespace Unity.Netcode.Components
         {
             if (networkManager.IsListening)
             {
-                return (float)networkManager.LocalTime.TimeTicksAgo(networkManager.NetworkTimeSystem.TickLatency + InterpolationBufferTickOffset).Time;
+                return (float)networkManager.ServerTime.TimeTicksAgo(networkManager.NetworkTimeSystem.TickLatency + InterpolationBufferTickOffset).Time;
             }
             return 0f;
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformInterpolationRenderTimeTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformInterpolationRenderTimeTests.cs
@@ -13,19 +13,10 @@ namespace Unity.Netcode.RuntimeTests
     /// clock that the state updates it is interpolating between are stamped on.
     /// </summary>
     /// <remarks>
-    /// A <see cref="NetworkTransform"/> state's SentTime is derived from its NetworkTick, which is a server
-    /// tick, so the render time has to be measured from ServerTime. Measuring it from LocalTime mixes two
-    /// clocks: LocalTime leads ServerTime, so subtracting the tick latency from LocalTime lands the render time
-    /// back at approximately ServerTime rather than a whole tick latency behind it. The interpolator is then
-    /// asked to render a point in time at (or ahead of) the newest state that can possibly exist, so it has
-    /// nothing left to interpolate towards.
-    ///
-    /// What this test measures is how far behind ServerTime the state currently being interpolated towards was
-    /// sent. Because the target is selected against the render time, this has to be at least the tick latency:
-    /// the render time is ServerTime minus the tick latency, and only states sent at or before the render time
-    /// are eligible. Deriving the render time from LocalTime instead eats into that margin by however far the
-    /// two clocks are apart, and can push the target past ServerTime entirely (a negative value below, meaning
-    /// the interpolator is chasing a state that the server clock says has not happened yet).
+    /// Measures how far behind ServerTime the state being interpolated towards was sent. The render time is
+    /// ServerTime minus the tick latency and only states sent at or before it are eligible, so that measurement
+    /// can never be less than the tick latency. Deriving the render time from LocalTime eats into that margin by
+    /// however far the two clocks are apart, and can push the target past ServerTime entirely.
     /// </remarks>
     [TestFixture(HostOrServer.Host, NetworkTransform.InterpolationTypes.Lerp)]
     [TestFixture(HostOrServer.Host, NetworkTransform.InterpolationTypes.SmoothDampening)]
@@ -33,12 +24,9 @@ namespace Unity.Netcode.RuntimeTests
     {
         protected override int NumberOfClients => 1;
 
-        // How far LocalTime is pushed ahead of ServerTime, in ticks. An in-process integration test has
-        // effectively no round trip time and the separation between the two clocks is
-        // (half RTT + LocalBufferSec + ServerBufferSec), so without widening the local buffer the two clocks
-        // sit close enough together that which one is used barely shows. This is deliberately large enough to
-        // exceed NetworkTimeSystem's hard reset threshold (0.2s) so the offset snaps rather than converging at
-        // the default adjustment ratio of 0.01s per second, which would take over ten seconds.
+        // How far LocalTime is pushed ahead of ServerTime, in ticks. An in-process test has no round trip time
+        // to separate the two clocks, and this is large enough to exceed NetworkTimeSystem's hard reset
+        // threshold so the offset snaps instead of converging at its default adjustment ratio.
         private const int k_LocalBufferTicks = 12;
 
         // The separation the clocks must actually reach before any measurement is taken.
@@ -47,11 +35,10 @@ namespace Unity.Netcode.RuntimeTests
         // Ticks of authority motion after the clocks have separated, so the interpolator reaches steady state.
         private const int k_WarmUpTicks = 20;
 
-        // The number of rendered frames sampled once the warm up has completed.
         private const int k_SampledFrames = 90;
 
-        // The distance the authority moves each tick. Large enough that every tick produces a state update
-        // rather than being filtered out by the position threshold.
+        // Far enough each tick that every tick produces a state update rather than being filtered out by the
+        // position threshold.
         private const float k_DistancePerTick = 1.37f;
 
         private readonly NetworkTransform.InterpolationTypes m_InterpolationType;
@@ -223,9 +210,7 @@ namespace Unity.Netcode.RuntimeTests
                 var meanBuffered = totalBuffered[instance] / (float)samples[instance];
                 var tickLatency = networkManager.NetworkTimeSystem.TickLatency;
 
-                // Only states sent at or before the render time are eligible to be interpolated towards, and the
-                // render time is the server clock minus the tick latency, so the target can never be newer than
-                // that. Anything less means the render time was taken from a clock that runs ahead of the one
+                // Anything less than the tick latency means the render time came from a clock that leads the one
                 // the states are stamped on.
                 Assert.GreaterOrEqual(meanTargetLagTicks, tickLatency,
                     $"[{m_InterpolationType}] {instance.name} was interpolating towards a state sent " +

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformInterpolationRenderTimeTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformInterpolationRenderTimeTests.cs
@@ -1,0 +1,239 @@
+using System.Collections;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Unity.Netcode.Components;
+using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Unity.Netcode.RuntimeTests
+{
+    /// <summary>
+    /// Validates that the render time a non-authority instance interpolates towards is derived from the same
+    /// clock that the state updates it is interpolating between are stamped on.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="NetworkTransform"/> state's SentTime is derived from its NetworkTick, which is a server
+    /// tick, so the render time has to be measured from ServerTime. Measuring it from LocalTime mixes two
+    /// clocks: LocalTime leads ServerTime, so subtracting the tick latency from LocalTime lands the render time
+    /// back at approximately ServerTime rather than a whole tick latency behind it. The interpolator is then
+    /// asked to render a point in time at (or ahead of) the newest state that can possibly exist, so it has
+    /// nothing left to interpolate towards.
+    ///
+    /// What this test measures is how far behind ServerTime the state currently being interpolated towards was
+    /// sent. Because the target is selected against the render time, this has to be at least the tick latency:
+    /// the render time is ServerTime minus the tick latency, and only states sent at or before the render time
+    /// are eligible. Deriving the render time from LocalTime instead eats into that margin by however far the
+    /// two clocks are apart, and can push the target past ServerTime entirely (a negative value below, meaning
+    /// the interpolator is chasing a state that the server clock says has not happened yet).
+    /// </remarks>
+    [TestFixture(HostOrServer.Host, NetworkTransform.InterpolationTypes.Lerp)]
+    [TestFixture(HostOrServer.Host, NetworkTransform.InterpolationTypes.SmoothDampening)]
+    internal class NetworkTransformInterpolationRenderTimeTests : IntegrationTestWithApproximation
+    {
+        protected override int NumberOfClients => 1;
+
+        // How far LocalTime is pushed ahead of ServerTime, in ticks. An in-process integration test has
+        // effectively no round trip time and the separation between the two clocks is
+        // (half RTT + LocalBufferSec + ServerBufferSec), so without widening the local buffer the two clocks
+        // sit close enough together that which one is used barely shows. This is deliberately large enough to
+        // exceed NetworkTimeSystem's hard reset threshold (0.2s) so the offset snaps rather than converging at
+        // the default adjustment ratio of 0.01s per second, which would take over ten seconds.
+        private const int k_LocalBufferTicks = 12;
+
+        // The separation the clocks must actually reach before any measurement is taken.
+        private const double k_RequiredLeadTicks = 8.0d;
+
+        // Ticks of authority motion after the clocks have separated, so the interpolator reaches steady state.
+        private const int k_WarmUpTicks = 20;
+
+        // The number of rendered frames sampled once the warm up has completed.
+        private const int k_SampledFrames = 90;
+
+        // The distance the authority moves each tick. Large enough that every tick produces a state update
+        // rather than being filtered out by the position threshold.
+        private const float k_DistancePerTick = 1.37f;
+
+        private readonly NetworkTransform.InterpolationTypes m_InterpolationType;
+
+        private GameObject m_TestPrefab;
+        private NetworkManager m_AuthorityNetworkManager;
+        private NetworkTransform m_AuthorityInstance;
+        private Vector3 m_Direction;
+        private int m_TickCount;
+
+        public NetworkTransformInterpolationRenderTimeTests(HostOrServer hostOrServer, NetworkTransform.InterpolationTypes interpolationType) : base(hostOrServer)
+        {
+            m_InterpolationType = interpolationType;
+        }
+
+        // TODO: [CmbServiceTests] ServerTime's meaning under a CMB service session has not been verified.
+        protected override bool UseCMBService()
+        {
+            return false;
+        }
+
+        protected override void OnServerAndClientsCreated()
+        {
+            m_TestPrefab = CreateNetworkObjectPrefab("RenderTimeTestObj");
+            var networkTransform = m_TestPrefab.AddComponent<NetworkTransform>();
+            networkTransform.PositionInterpolationType = m_InterpolationType;
+            base.OnServerAndClientsCreated();
+        }
+
+        private static double GetTickInterval(NetworkManager networkManager)
+        {
+            return 1.0d / networkManager.NetworkTickSystem.TickRate;
+        }
+
+        /// <summary>
+        /// How far LocalTime currently leads ServerTime, expressed in ticks.
+        /// </summary>
+        private static double GetClockLeadInTicks(NetworkManager networkManager)
+        {
+            return (networkManager.LocalTime.Time - networkManager.ServerTime.Time) / GetTickInterval(networkManager);
+        }
+
+        /// <summary>
+        /// Moves the authority instance once per tick so that a state update is generated every tick.
+        /// </summary>
+        private void OnNetworkTick()
+        {
+            m_TickCount++;
+            m_AuthorityInstance.transform.position += m_Direction * k_DistancePerTick;
+        }
+
+        private bool AllClientsSpawnedInstance()
+        {
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                if (networkManager == m_AuthorityNetworkManager)
+                {
+                    continue;
+                }
+
+                if (!networkManager.SpawnManager.SpawnedObjects.ContainsKey(m_AuthorityInstance.NetworkObject.NetworkObjectId))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        private List<NetworkTransform> GetNonAuthorityInstances()
+        {
+            var instances = new List<NetworkTransform>();
+            foreach (var networkManager in m_NetworkManagers)
+            {
+                if (networkManager == m_AuthorityNetworkManager)
+                {
+                    continue;
+                }
+
+                var spawnedObject = networkManager.SpawnManager.SpawnedObjects[m_AuthorityInstance.NetworkObject.NetworkObjectId];
+                instances.Add(spawnedObject.GetComponent<NetworkTransform>());
+            }
+            return instances;
+        }
+
+        [UnityTest]
+        public IEnumerator RenderTimeTrailsTheServerClock()
+        {
+            m_AuthorityNetworkManager = GetAuthorityNetworkManager();
+            m_AuthorityInstance = SpawnObject(m_TestPrefab, m_AuthorityNetworkManager).GetComponent<NetworkTransform>();
+
+            yield return WaitForConditionOrTimeOut(AllClientsSpawnedInstance);
+            AssertOnTimeout($"Not all clients spawned {m_AuthorityInstance.name}!");
+
+            var nonAuthorityInstances = GetNonAuthorityInstances();
+            Assert.IsNotEmpty(nonAuthorityInstances, "There were no non-authority instances to measure!");
+
+            // Separate the two clocks by a known amount so that which one the render time is derived from is
+            // actually distinguishable.
+            foreach (var instance in nonAuthorityInstances)
+            {
+                var networkManager = instance.NetworkManager;
+                networkManager.NetworkTimeSystem.LocalBufferSec = k_LocalBufferTicks * GetTickInterval(networkManager);
+            }
+
+            // Start continuous motion on the authority.
+            m_Direction = GetRandomVector3(-10, 10).normalized;
+            m_TickCount = 0;
+            m_AuthorityNetworkManager.NetworkTickSystem.Tick += OnNetworkTick;
+
+            // The offset only moves when the client next receives a time sync, so wait for the separation to
+            // actually take hold rather than assuming it has.
+            yield return WaitForConditionOrTimeOut(() =>
+            {
+                foreach (var instance in nonAuthorityInstances)
+                {
+                    if (GetClockLeadInTicks(instance.NetworkManager) < k_RequiredLeadTicks)
+                    {
+                        return false;
+                    }
+                }
+                return true;
+            });
+            AssertOnTimeout($"The client clocks never separated by {k_RequiredLeadTicks} ticks, so this test " +
+                $"cannot tell the two clocks apart and would pass regardless of which one is used.");
+
+            // Let the interpolator settle at the new separation before measuring.
+            var warmUpTarget = m_TickCount + k_WarmUpTicks;
+            yield return WaitForConditionOrTimeOut(() => m_TickCount >= warmUpTarget);
+            AssertOnTimeout("Timed out waiting for the authority to keep moving!");
+
+            // Sample how far behind ServerTime the state being interpolated towards was sent.
+            var totalTargetLagTicks = new Dictionary<NetworkTransform, double>();
+            var totalBuffered = new Dictionary<NetworkTransform, int>();
+            var samples = new Dictionary<NetworkTransform, int>();
+            foreach (var instance in nonAuthorityInstances)
+            {
+                totalTargetLagTicks.Add(instance, 0.0d);
+                totalBuffered.Add(instance, 0);
+                samples.Add(instance, 0);
+            }
+
+            for (int frame = 0; frame < k_SampledFrames; frame++)
+            {
+                foreach (var instance in nonAuthorityInstances)
+                {
+                    var interpolator = instance.GetPositionInterpolator();
+                    if (!interpolator.InterpolateState.Target.HasValue)
+                    {
+                        continue;
+                    }
+
+                    var networkManager = instance.NetworkManager;
+                    var targetLag = networkManager.ServerTime.Time - interpolator.InterpolateState.Target.Value.TimeSent;
+                    totalTargetLagTicks[instance] += targetLag / GetTickInterval(networkManager);
+                    totalBuffered[instance] += interpolator.m_BufferQueue.Count;
+                    samples[instance]++;
+                }
+                yield return null;
+            }
+
+            m_AuthorityNetworkManager.NetworkTickSystem.Tick -= OnNetworkTick;
+
+            foreach (var instance in nonAuthorityInstances)
+            {
+                Assert.Greater(samples[instance], 0, $"{instance.name} never had a state to interpolate towards!");
+
+                var networkManager = instance.NetworkManager;
+                var meanTargetLagTicks = totalTargetLagTicks[instance] / samples[instance];
+                var meanBuffered = totalBuffered[instance] / (float)samples[instance];
+                var tickLatency = networkManager.NetworkTimeSystem.TickLatency;
+
+                // Only states sent at or before the render time are eligible to be interpolated towards, and the
+                // render time is the server clock minus the tick latency, so the target can never be newer than
+                // that. Anything less means the render time was taken from a clock that runs ahead of the one
+                // the states are stamped on.
+                Assert.GreaterOrEqual(meanTargetLagTicks, tickLatency,
+                    $"[{m_InterpolationType}] {instance.name} was interpolating towards a state sent " +
+                    $"{meanTargetLagTicks:F3} ticks behind the server clock, but the render time is the server " +
+                    $"clock minus a tick latency of {tickLatency}, so it should never be less than that. " +
+                    $"(clock lead {GetClockLeadInTicks(networkManager):F3} ticks, mean buffered {meanBuffered:F3}). " +
+                    $"The render time is being derived from a clock that leads the one state updates are stamped on.");
+            }
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformInterpolationRenderTimeTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/NetworkTransform/NetworkTransformInterpolationRenderTimeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: acef3f08e52a1e143bbffdddb16cdfc5


### PR DESCRIPTION
## Purpose of this PR

This is a back port of #4133.

### Jira ticket

NA

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)

- Fixed: Issue where `NetworkTransform` interpolated towards a point in time taken from the local clock rather than the server clock that state updates are stamped on, which starved the interpolator on clients and reduced interpolation to snapping between state updates.
- Fixed: Issue where `NetworkTransform.GetTickLatencyInSeconds` returned a time based on the local clock instead of the server clock used for interpolation.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation

- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)

New integration test measures how far behind `ServerTime` the state being interpolated towards was sent. That value can never be less than the tick latency, since the render time is `ServerTime` minus the tick latency and only states sent at or before it are eligible.

Validated in both directions on `develop-2.0.0`: without the fix both fixtures fail, reporting the target as **−0.899** and **−1.059** ticks — the interpolator chasing a state the server clock says has not happened yet. With the fix both pass. The full `NetworkTransform` playmode suite is green (3942/3942).

The test widens the client's local time buffer before measuring, because an in-process test has no round trip time to separate the two clocks and would otherwise pass regardless of which one is used. It waits for that separation to take hold and fails if it never does, so it cannot silently become a no-op.

For release playtest, the thing to look at is client-side smoothness of moving networked objects, and whether the added latency is acceptable.

### Functional Testing

_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [x] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [x] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

## Up-port

No up-port since this is one.

## Backports

Not needed.