### PR TITLE
chore: Enable U-PR bot

### DIFF
--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,2 +1,9 @@
+# This is the configuration for the u-pr bot
+# https://github.cds.internal.unity3d.com/unity/u-pr
+# For configuration of this file:
+# https://developer.portal.internal.unity.com/catalog/default/component/u-pr/docs/configuration/automatic_runs/
+
 [github_app]
-pr_commands = []
+handle_pr_actions = ['opened', 'ready_for_review']  # PR events that auto-run pr_commands
+pr_commands       = ["/harness-review"]             # what runs on those events
+reviewer_commands = ["/harness-review"]             # what runs when @u-pr is added as reviewer

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/SceneManagementSynchronizationTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/SceneManagementSynchronizationTests.cs
@@ -57,7 +57,7 @@ namespace TestProject.RuntimeTests
                 {
                     predicate(expectedEvent);
                 }
-                catch(Exception failure)
+                catch (Exception failure)
                 {
                     Debug.LogException(failure);
                 }

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/SceneManagementSynchronizationTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/SceneManagementSynchronizationTests.cs
@@ -242,7 +242,7 @@ namespace TestProject.RuntimeTests
 
         private static void ValidateConnectionEventsAreEqual(ExpectedEvent expectedEvent, ConnectionEventData eventData)
         {
-            Assert.That(expectedEvent.IsSceneEvent, Is.False, $"Received unexpected connection event {eventData.EventType} at index {s_NumEventsProcessed}. Expected scene event: {expectedEvent.SceneEvent.SceneEventType}");
+            Assert.That(expectedEvent.IsSceneEvent, Is.False, $"Received unexpected connection event {eventData.EventType} at index {s_NumEventsProcessed}. Expected scene event: {expectedEvent.ConnectionEvent.EventType}");
             AssertField(expectedEvent.ConnectionEvent.EventType, eventData.EventType, nameof(eventData.EventType), eventData.EventType);
             AssertField(expectedEvent.ConnectionEvent.ClientId, eventData.ClientId, nameof(eventData.ClientId), eventData.EventType);
 

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/SceneManagementSynchronizationTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/SceneManagementSynchronizationTests.cs
@@ -6,6 +6,7 @@ using NUnit.Framework;
 using Unity.Collections;
 using Unity.Netcode;
 using Unity.Netcode.TestHelpers.Runtime;
+using UnityEngine;
 using UnityEngine.TestTools;
 
 namespace TestProject.RuntimeTests
@@ -24,6 +25,7 @@ namespace TestProject.RuntimeTests
 
         private struct ExpectedEvent
         {
+            public bool IsSceneEvent;
             public SceneEvent SceneEvent;
             public ConnectionEventData ConnectionEvent;
         }
@@ -51,13 +53,19 @@ namespace TestProject.RuntimeTests
             if (m_ExpectedEventQueue.Count > 0)
             {
                 var expectedEvent = m_ExpectedEventQueue.Dequeue();
-                predicate(expectedEvent);
+                try
+                {
+                    predicate(expectedEvent);
+                }
+                catch(Exception failure)
+                {
+                    Debug.LogException(failure);
+                }
             }
             else
             {
                 Assert.Fail($"Received unexpected event at index {s_NumEventsProcessed}: {eventType}");
             }
-
             s_NumEventsProcessed++;
         }
 
@@ -100,42 +108,30 @@ namespace TestProject.RuntimeTests
             var expectedClientId = GetNonAuthorityNetworkManager().LocalClientId + 1;
 
             // Setup expected events
-            m_ExpectedEventQueue.Enqueue(new ExpectedEvent()
+            AddExpectedEvent(new SceneEvent()
             {
-                SceneEvent = new SceneEvent()
-                {
-                    SceneEventType = SceneEventType.Synchronize,
-                    ClientId = expectedClientId
-                },
+                SceneEventType = SceneEventType.Synchronize,
+                ClientId = expectedClientId
             });
 
-            m_ExpectedEventQueue.Enqueue(new ExpectedEvent()
+            AddExpectedEvent(new SceneEvent()
             {
-                SceneEvent = new SceneEvent()
-                {
-                    SceneEventType = SceneEventType.SynchronizeComplete,
-                    ClientId = expectedClientId,
-                },
+                SceneEventType = SceneEventType.SynchronizeComplete,
+                ClientId = expectedClientId,
             });
 
-            m_ExpectedEventQueue.Enqueue(new ExpectedEvent()
+            AddExpectedEvent(new ConnectionEventData()
             {
-                ConnectionEvent = new ConnectionEventData()
-                {
-                    EventType = ConnectionEvent.ClientConnected,
-                    ClientId = expectedClientId,
-                }
+                EventType = ConnectionEvent.ClientConnected,
+                ClientId = expectedClientId,
             });
 
             if (m_UseHost)
             {
-                m_ExpectedEventQueue.Enqueue(new ExpectedEvent()
+                AddExpectedEvent(new ConnectionEventData()
                 {
-                    ConnectionEvent = new ConnectionEventData()
-                    {
-                        EventType = ConnectionEvent.PeerConnected,
-                        ClientId = expectedClientId,
-                    }
+                    EventType = ConnectionEvent.PeerConnected,
+                    ClientId = expectedClientId,
                 });
             }
 
@@ -158,31 +154,22 @@ namespace TestProject.RuntimeTests
             var expectedPeerClientIds = m_UseHost ? new[] { authorityId, peerClientId } : new[] { peerClientId };
 
             // Setup expected events
-            m_ExpectedEventQueue.Enqueue(new ExpectedEvent()
+            AddExpectedEvent(new SceneEvent()
             {
-                SceneEvent = new SceneEvent()
-                {
-                    SceneEventType = SceneEventType.Synchronize,
-                    ClientId = expectedClientId,
-                },
+                SceneEventType = SceneEventType.Synchronize,
+                ClientId = expectedClientId,
             });
-            m_ExpectedEventQueue.Enqueue(new ExpectedEvent()
+            AddExpectedEvent(new ConnectionEventData()
             {
-                ConnectionEvent = new ConnectionEventData()
-                {
-                    EventType = ConnectionEvent.ClientConnected,
-                    ClientId = expectedClientId,
-                    PeerClientIds = new NativeArray<ulong>(expectedPeerClientIds.ToArray(), Allocator.Persistent),
-                }
+                EventType = ConnectionEvent.ClientConnected,
+                ClientId = expectedClientId,
+                PeerClientIds = new NativeArray<ulong>(expectedPeerClientIds.ToArray(), Allocator.Persistent),
             });
 
-            m_ExpectedEventQueue.Enqueue(new ExpectedEvent()
+            AddExpectedEvent(new SceneEvent()
             {
-                SceneEvent = new SceneEvent()
-                {
-                    SceneEventType = SceneEventType.SynchronizeComplete,
-                    ClientId = expectedClientId,
-                },
+                SceneEventType = SceneEventType.SynchronizeComplete,
+                ClientId = expectedClientId,
             });
 
             Assert.Null(m_ManagerToTest, "m_ManagerToTest should be null as we should be testing newly created client");
@@ -203,27 +190,22 @@ namespace TestProject.RuntimeTests
             var nonAuthority = GetNonAuthorityNetworkManager();
             var expectedClientId = nonAuthority.LocalClientId + 1;
             SetManagerToTest(nonAuthority);
+
             // Setup expected events
+            AddExpectedEvent(new ConnectionEventData()
+            {
+                EventType = ConnectionEvent.PeerConnected,
+                ClientId = expectedClientId,
+            });
+
             if (m_UseCmbService)
             {
-                m_ExpectedEventQueue.Enqueue(new ExpectedEvent()
+                AddExpectedEvent(new SceneEvent()
                 {
-                    SceneEvent = new SceneEvent()
-                    {
-                        SceneEventType = SceneEventType.SynchronizeComplete,
-                        ClientId = expectedClientId,
-                    },
+                    SceneEventType = SceneEventType.SynchronizeComplete,
+                    ClientId = expectedClientId,
                 });
             }
-
-            m_ExpectedEventQueue.Enqueue(new ExpectedEvent()
-            {
-                ConnectionEvent = new ConnectionEventData()
-                {
-                    EventType = ConnectionEvent.PeerConnected,
-                    ClientId = expectedClientId,
-                }
-            });
 
             //////////////////////////////////////////
             // Testing event notifications
@@ -233,16 +215,34 @@ namespace TestProject.RuntimeTests
             Assert.IsEmpty(m_ExpectedEventQueue, "Not all expected callbacks were received");
         }
 
+        private void AddExpectedEvent(SceneEvent expectedEvent)
+        {
+            m_ExpectedEventQueue.Enqueue(new ExpectedEvent()
+            {
+                IsSceneEvent = true,
+                SceneEvent = expectedEvent,
+            });
+        }
+
+        private void AddExpectedEvent(ConnectionEventData expectedEvent)
+        {
+            m_ExpectedEventQueue.Enqueue(new ExpectedEvent()
+            {
+                IsSceneEvent = false,
+                ConnectionEvent = expectedEvent,
+            });
+        }
+
         private static void ValidateSceneEventsAreEqual(ExpectedEvent expectedEvent, SceneEvent sceneEvent)
         {
-            Assert.NotNull(expectedEvent.SceneEvent, $"Received unexpected scene event {sceneEvent.SceneEventType} at index {s_NumEventsProcessed}");
+            Assert.That(expectedEvent.IsSceneEvent, Is.True, $"Received unexpected scene event {sceneEvent.SceneEventType} at index {s_NumEventsProcessed}. Expected connection event: {expectedEvent.ConnectionEvent.EventType}");
             AssertField(expectedEvent.SceneEvent.SceneEventType, sceneEvent.SceneEventType, nameof(sceneEvent.SceneEventType), sceneEvent.SceneEventType);
             AssertField(expectedEvent.SceneEvent.ClientId, sceneEvent.ClientId, nameof(sceneEvent.ClientId), sceneEvent.SceneEventType);
         }
 
         private static void ValidateConnectionEventsAreEqual(ExpectedEvent expectedEvent, ConnectionEventData eventData)
         {
-            Assert.NotNull(expectedEvent.ConnectionEvent, $"Received unexpected connection event {eventData.EventType} at index {s_NumEventsProcessed}");
+            Assert.That(expectedEvent.IsSceneEvent, Is.False, $"Received unexpected connection event {eventData.EventType} at index {s_NumEventsProcessed}. Expected scene event: {expectedEvent.SceneEvent.SceneEventType}");
             AssertField(expectedEvent.ConnectionEvent.EventType, eventData.EventType, nameof(eventData.EventType), eventData.EventType);
             AssertField(expectedEvent.ConnectionEvent.ClientId, eventData.ClientId, nameof(eventData.ClientId), eventData.EventType);
 


### PR DESCRIPTION
## Purpose of this PR

Enables the U-PR bot to auto-run whenever a PR is opened, and when it is moved out of draft.


Also, swaps the order of some callbacks in the `SceneManagementSynchronizationTests` due to changes in the CMB service
Related CMB Service work:
* [UPS-1556](https://github.com/Unity-Technologies/unity-player-services/pull/1556)
* [UPS-1570](https://github.com/Unity-Technologies/unity-player-services/pull/1570)

### Jira ticket
n/a

### Changelog

internal change only

## Documentation

- No documentation changes or additions were necessary.

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [ ] `Manual testing done`

_Automated tests:_
- [x] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Up-port
#4139

## Backports
Probably doesn't need a backport.
