### PR TITLE
feat: expose BufferedLinearInterpolator's less smoothed Update

### DIFF
--- a/com.unity.netcode.gameobjects/Runtime/Components/Interpolator/BufferedLinearInterpolator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Interpolator/BufferedLinearInterpolator.cs
@@ -433,7 +433,7 @@ namespace Unity.Netcode
         /// <param name="maxDeltaTime">The maximum time delta between the current and target value.</param>
         /// <param name="lerp">Determines whether to use smooth dampening or lerp interpolation type.</param>
         /// <returns>The newly interpolated value of type 'T'</returns>
-        internal T Update(float deltaTime, double tickLatencyAsTime, double minDeltaTime, double maxDeltaTime, bool lerp)
+        public T Update(float deltaTime, double tickLatencyAsTime, double minDeltaTime, double maxDeltaTime, bool lerp)
         {
             TryConsumeFromBuffer(tickLatencyAsTime, minDeltaTime, maxDeltaTime);
             // Only begin interpolation when there is a start and end point


### PR DESCRIPTION
## Purpose of this PR
[//]: # (
Replace this block with what this PR does and why. Describe what you'd like reviewers to know, how you applied the engineering principles, and any interesting tradeoffs made. 
)
Exposed the more precise version of BufferedLinearInterpolator. The other update method is exposed but is more smoothed as explained in its existing doc. I've been using this more precise version and manually exposing it when the package is updated. I don't see a reason for it to be internal only.

### Changelog   
- Changed: [BufferedLinearInterpolator.Update(float deltaTime, double tickLatencyAsTime, double minDeltaTime, double maxDeltaTime, bool lerp)](https://github.com/ToxPlayers/com.unity.netcode.gameobjects/blob/develop-2.0.0/com.unity.netcode.gameobjects/Runtime/Components/Interpolator/BufferedLinearInterpolator.cs?plain=1#L436)  scope from internal to public.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)
- No documentation changes or additions were necessary. 

## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)
I've been using the function for my projects for a while and also tested it in this branch with no issues.
<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [x] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [ ] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Up-port
[//]: # (
This section is REQUIRED and should link to the PR that targets develop-3.0.0 branch. Assuming that the PR lands agains default develop-2.0.0 branch
If this is not needed, for example feature specific to NGOv2.X, then just mention this fact.
)
Needed, should be exposed in 3.0.0 too

## Backports
[//]: # (
This section is REQUIRED and should link to the PR that targets other NGO version which is either develop or develop-2.0.0 branch
Add the following to the PR title: "\[Backport\] ..."
If this is not needed, for example feature specific to NGOv2.X, then just mention this fact.
)
Not needed
