### PR TITLE
fix: server not tracking scene handles for pre-loaded scenes

### DIFF
--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -22,6 +22,8 @@ Additional documentation and release notes are available at [Multiplayer Documen
 
 ### Fixed
 
+- Fixed issue where scenes additively loaded before a session started were tracked as loaded on the server but had no scene handle entries, which caused `NetworkSceneManager.UnloadScene` to log an error and leave the scene registered as loaded even though it unloaded on all peers. (#4145)
+
 
 ### Security
 

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -847,7 +847,7 @@ namespace Unity.Netcode
                 for (int i = 0; i < SceneManager.sceneCount; i++)
                 {
                     var loadedScene = SceneManager.GetSceneAt(i);
-                    ScenesLoaded.Add(loadedScene.handle, loadedScene);
+                    UpdateServerClientSceneHandle(loadedScene.handle, loadedScene.handle, loadedScene);
                 }
                 SceneManagerHandler.PopulateLoadedScenes(ref ScenesLoaded, NetworkManager);
             }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTestHelpers.cs
@@ -542,10 +542,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 }
 
                 // The server already registers every scene loaded prior to startup, so only add the test runner scene if it is not already there.
-                if (!networkManager.SceneManager.ServerSceneHandleToClientSceneHandle.ContainsKey(scene.handle))
-                {
-                    networkManager.SceneManager.ServerSceneHandleToClientSceneHandle.Add(scene.handle, scene.handle);
-                }
+            networkManager.SceneManager.ServerSceneHandleToClientSceneHandle.TryAdd(scene.handle, scene.handle);
             }
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTestHelpers.cs
@@ -540,7 +540,12 @@ namespace Unity.Netcode.TestHelpers.Runtime
                     }
                     return;
                 }
-                networkManager.SceneManager.ServerSceneHandleToClientSceneHandle.Add(scene.handle, scene.handle);
+
+                // The server already registers every scene loaded prior to startup, so only add the test runner scene if it is not already there.
+                if (!networkManager.SceneManager.ServerSceneHandleToClientSceneHandle.ContainsKey(scene.handle))
+                {
+                    networkManager.SceneManager.ServerSceneHandleToClientSceneHandle.Add(scene.handle, scene.handle);
+                }
             }
         }
 

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTestHelpers.cs
@@ -542,7 +542,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
                 }
 
                 // The server already registers every scene loaded prior to startup, so only add the test runner scene if it is not already there.
-            networkManager.SceneManager.ServerSceneHandleToClientSceneHandle.TryAdd(scene.handle, scene.handle);
+                networkManager.SceneManager.ServerSceneHandleToClientSceneHandle.TryAdd(scene.handle, scene.handle);
             }
         }
 

--- a/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerStartupTests.cs
+++ b/testproject/Assets/Tests/Runtime/NetworkSceneManager/NetworkSceneManagerStartupTests.cs
@@ -21,6 +21,7 @@ namespace TestProject.RuntimeTests
     {
         private const string k_ActiveScene = "SessionSynchronize";
         private const string k_AdditionalScene = "InSceneNetworkObjectMovesToDDOL";
+        private const string k_PreLoadedScene = "EmptyScene1";
 
         private readonly List<NetworkObject> m_ObjectsInScenes = new List<NetworkObject>();
         private Scene m_OriginalActiveScene;
@@ -139,6 +140,35 @@ namespace TestProject.RuntimeTests
             // Wait for all existing objects to spawn on the client
             yield return WaitForSpawnedOnAllOrTimeOut(existingObjects);
             AssertOnTimeout("Timed out waiting for objects to spawn on all clients!");
+        }
+
+        /// <summary>
+        /// Validates that a scene additively loaded before the session started is tracked well enough
+        /// to be unloaded through <see cref="NetworkSceneManager"/> without error.
+        /// </summary>
+        [UnityTest]
+        public IEnumerator UnloadPreLoadedScene()
+        {
+            yield return PreLoadScene(k_PreLoadedScene);
+            var preLoadedScene = m_SceneLoaded;
+
+            m_CanStart = true;
+            yield return StartServerAndClients();
+
+            // Scenes loaded before the session started are registered in both the loaded scenes and the
+            // scene handle tables, otherwise unloading them fails part way through and leaks the entry.
+            var sceneManager = GetAuthorityNetworkManager().SceneManager;
+            Assert.IsTrue(sceneManager.ScenesLoaded.ContainsKey(preLoadedScene.handle), $"{k_PreLoadedScene} is not in {nameof(NetworkSceneManager.ScenesLoaded)}!");
+            Assert.IsTrue(sceneManager.ServerSceneHandleToClientSceneHandle.ContainsKey(preLoadedScene.handle), $"{k_PreLoadedScene} is not in {nameof(NetworkSceneManager.ServerSceneHandleToClientSceneHandle)}!");
+
+            var status = sceneManager.UnloadScene(preLoadedScene);
+            Assert.AreEqual(SceneEventProgressStatus.Started, status, $"{nameof(NetworkSceneManager.UnloadScene)} returned {status}!");
+
+            yield return WaitForConditionOrTimeOut(() => !preLoadedScene.isLoaded);
+            AssertOnTimeout($"Timed out waiting for {k_PreLoadedScene} to unload!");
+
+            Assert.IsFalse(sceneManager.ScenesLoaded.ContainsKey(preLoadedScene.handle), $"{k_PreLoadedScene} was unloaded but is still in {nameof(NetworkSceneManager.ScenesLoaded)}!");
+            Assert.IsFalse(sceneManager.ServerSceneHandleToClientSceneHandle.ContainsKey(preLoadedScene.handle), $"{k_PreLoadedScene} was unloaded but is still in {nameof(NetworkSceneManager.ServerSceneHandleToClientSceneHandle)}!");
         }
 
         #region Scene loading and related methods


### PR DESCRIPTION
## Purpose of this PR
Scenes that were already loaded when a session starts were added to ScenesLoaded but never to the server-to-client scene handle tables, so UnloadScene passed its ScenesLoaded check and then failed inside RemoveServerClientSceneHandle. The scene unloaded on every peer, but an error was logged and the ScenesLoaded entry was never removed.

The client-server branch of the NetworkSceneManager constructor now registers those scenes the same way InitializeScenesLoaded does for distributed authority.

NetcodeIntegrationTestHelpers registered the test runner scene in ServerSceneHandleToClientSceneHandle unconditionally, which now collides with the constructor already having added it, so that add is guarded.

fix: #4140


### Jira ticket

(Needs ticket)

### Changelog
[//]: # (updated with all public facing changes  - API changes, UI/UX changes, behaviour changes, bug fixes. Remove if not relevant.)

- Fixed: Issue where scenes additively loaded before a session started were tracked as loaded on the server but had no scene handle entries, which caused `NetworkSceneManager.UnloadScene` to log an error and leave the scene registered as loaded even though it unloaded on all peers.

<!--  Uncomment and mark items off with a * if this PR deprecates any API:
### Deprecated API
- [ ] An `[Obsolete]` attribute was added along with a `(RemovedAfter yyyy-mm-dd)` entry.
- [ ] An [api updater](https://confluence.unity3d.com/display/DEV/Obsolete+API+updaters) was added.
- [ ] Deprecation of the API is explained in the CHANGELOG.
- [ ] The users can understand why this API was removed and what they should use instead.
-->

## Documentation
[//]: # (
This section is REQUIRED and should mention what documentation changes were following the changes in this PR. 
We should always evaluate if the changes in this PR require any documentation changes.
)

- No documentation changes or additions were necessary.


## Testing & QA (How your changes can be verified during release Playtest)
[//]: #  (
This section is REQUIRED and should describe how the changes were tested and how should they be tested when Playtesting for the release.
It can range from "edge case covered by unit tests" to "manual testing required and new sample was added".
Expectation is that PR creator does some manual testing and provides a summary of it here.)

<!-- Add any performance testing results here if relevant. -->

### Functional Testing
[//]: # (If checked, List manual tests that have been performed.)
_Manual testing :_
- [x] `Manual testing done`

_Automated tests:_
- [ ] `Covered by existing automated tests`
- [x] `Covered by new automated tests`

_Does the change require QA team to:_

- [ ] `Review automated tests`?
- [ ] `Execute manual tests`?
- [ ] `Provide feedback about the PR`?

If any boxes above are checked the QA team will be automatically added as a PR reviewer.

## Up-port

Up-port: #4146
Requires up-port.

## Backports

No backport required.