### PR TITLE
chore: Swap Obsolete tags from warning to error

### DIFF
--- a/Examples/OverridingScenesAndPrefabs/Assets/Scripts/NetworkManagerBootstrapper.cs
+++ b/Examples/OverridingScenesAndPrefabs/Assets/Scripts/NetworkManagerBootstrapper.cs
@@ -499,7 +499,7 @@ public class NetworkManagerBootstrapper : NetworkManager
             // Set the application frame rate to like 30 to reduce frame processing overhead
             Application.targetFrameRate = 30;
 
-            Debug.Log($"[Pre-Init] Server Address Endpoint: {m_UnityTransport.ConnectionData.ServerEndPoint}");
+            Debug.Log($"[Pre-Init] Server Address Endpoint: {m_UnityTransport.ConnectionData.Address}:{m_UnityTransport.ConnectionData.Port}");
             Debug.Log($"[Pre-Init] Server Listen Endpoint: {m_UnityTransport.ConnectionData.ListenEndPoint}");
             // Setup your IP and port sepcific to your DGS
             //unityTransport.SetConnectionData(ListenAddress, ListenPort, ListenAddress);
@@ -527,7 +527,7 @@ public class NetworkManagerBootstrapper : NetworkManager
     private void ServerStarted()
     {
         Debug.Log("Dedicated Server Started!");
-        Debug.Log($"[Started] Server Address Endpoint: {m_UnityTransport.ConnectionData.ServerEndPoint}");
+        Debug.Log($"[Started] Server Address Endpoint: {m_UnityTransport.ConnectionData.Address}:{m_UnityTransport.ConnectionData.Port}");
         Debug.Log($"[Started] Server Listen Endpoint: {m_UnityTransport.ConnectionData.ListenEndPoint}");
         Debug.Log("===============================================================");
         Debug.Log("[X] Exits session (Shutdown) | [ESC] Exits application instance");

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -17,7 +17,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
   - `Unity.Netcode.Editor.CodeGen` → `Unity.Netcode.GameObjects.Editor.CodeGen`
   - `Unity.Netcode.Editor.PackageChecker` → `Unity.Netcode.GameObjects.Editor.PackageChecker`
   - `Unity.Netcode.Editor.Tests` → `Unity.Netcode.GameObjects.Editor.Tests`
-- Several APIs that were already marked `[Obsolete]` with a warning now raise a compile error instead (they are not removed yet): `NetworkObject.IsSceneObject`, `NetworkObject.SetSceneObjectStatus`, `NetworkList.LastModifiedTick`, `UnityTransport.InitialMaxSendQueueSize`, `UnityTransport.DebugSimulator`, `UnityTransport.SetDebugSimulatorParameters`, the deprecated `BufferedLinearInterpolator` buffer/interpolation fields and its testing-only `Update(float, NetworkTime)` overload, `NetworkSpawnManager.InternalOnOwnershipChanged`, `CommandLineOptions.Instance`, `CommandLineOptions.GetArg`, and `NotListeningException`.
+- Several APIs that were already marked `[Obsolete]` with a warning now raise a compile error instead (they are not removed yet): `RpcAttribute.RequireOwnership`, `ServerRpcAttribute.RequireOwnership`, `NetworkObject.IsSceneObject`, `NetworkObject.SetSceneObjectStatus`, `NetworkList.LastModifiedTick`, `UnityTransport.InitialMaxSendQueueSize`, `UnityTransport.DebugSimulator`, `UnityTransport.SetDebugSimulatorParameters`, `UnityTransport.ConnectionData.ServerEndPoint`, the deprecated `BufferedLinearInterpolator` buffer/interpolation fields and its testing-only `Update(float, NetworkTime)` overload, `NetworkSpawnManager.InternalOnOwnershipChanged`, `CommandLineOptions.Instance`, `CommandLineOptions.GetArg`, and `NotListeningException`.
 
 ### Deprecated
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -17,9 +17,10 @@ Additional documentation and release notes are available at [Multiplayer Documen
   - `Unity.Netcode.Editor.CodeGen` → `Unity.Netcode.GameObjects.Editor.CodeGen`
   - `Unity.Netcode.Editor.PackageChecker` → `Unity.Netcode.GameObjects.Editor.PackageChecker`
   - `Unity.Netcode.Editor.Tests` → `Unity.Netcode.GameObjects.Editor.Tests`
-- Several APIs that were already marked `[Obsolete]` with a warning now raise a compile error instead (they are not removed yet): `RpcAttribute.RequireOwnership`, `ServerRpcAttribute.RequireOwnership`, `NetworkObject.IsSceneObject`, `NetworkObject.SetSceneObjectStatus`, `NetworkList.LastModifiedTick`, `UnityTransport.InitialMaxSendQueueSize`, `UnityTransport.DebugSimulator`, `UnityTransport.SetDebugSimulatorParameters`, `UnityTransport.ConnectionData.ServerEndPoint`, the deprecated `BufferedLinearInterpolator` buffer/interpolation fields and its testing-only `Update(float, NetworkTime)` overload, `NetworkSpawnManager.InternalOnOwnershipChanged`, `CommandLineOptions.Instance`, `CommandLineOptions.GetArg`, and `NotListeningException`.
 
 ### Deprecated
+
+- Several APIs that were already marked `[Obsolete]` with a warning now raise a compile error instead (they are not removed yet).
 
 ### Removed
 

--- a/com.unity.netcode.gameobjects/CHANGELOG.md
+++ b/com.unity.netcode.gameobjects/CHANGELOG.md
@@ -17,6 +17,7 @@ Additional documentation and release notes are available at [Multiplayer Documen
   - `Unity.Netcode.Editor.CodeGen` → `Unity.Netcode.GameObjects.Editor.CodeGen`
   - `Unity.Netcode.Editor.PackageChecker` → `Unity.Netcode.GameObjects.Editor.PackageChecker`
   - `Unity.Netcode.Editor.Tests` → `Unity.Netcode.GameObjects.Editor.Tests`
+- Several APIs that were already marked `[Obsolete]` with a warning now raise a compile error instead (they are not removed yet): `NetworkObject.IsSceneObject`, `NetworkObject.SetSceneObjectStatus`, `NetworkList.LastModifiedTick`, `UnityTransport.InitialMaxSendQueueSize`, `UnityTransport.DebugSimulator`, `UnityTransport.SetDebugSimulatorParameters`, the deprecated `BufferedLinearInterpolator` buffer/interpolation fields and its testing-only `Update(float, NetworkTime)` overload, `NetworkSpawnManager.InternalOnOwnershipChanged`, `CommandLineOptions.Instance`, `CommandLineOptions.GetArg`, and `NotListeningException`.
 
 ### Deprecated
 

--- a/com.unity.netcode.gameobjects/Documentation~/advanced-topics/transports.md
+++ b/com.unity.netcode.gameobjects/Documentation~/advanced-topics/transports.md
@@ -1,6 +1,6 @@
 # Transports
 
-Unity Netcode for GameObjects (Netcode) uses Unity Transport by default and supports UNet Transport (deprecated) up to Unity 2022.2 version.
+Unity Netcode for GameObjects (Netcode) uses Unity Transport by default and also provides a single player transport.
 
 ## So what is a transport layer?
 
@@ -18,11 +18,13 @@ A transport layer can provide:
 
 Netcode's default transport Unity Transport is an entire transport layer that you can use to add multiplayer and network features to your project with or without Netcode. Refer to the Transport [documentation](https://docs.unity3d.com/Packages/com.unity.transport@latest) for more information and how to [install](https://docs.unity3d.com/Packages/com.unity.transport@latest?subfolder=/manual/install.html).
 
-## Unity's UNet Transport Layer API
+Netcode provides a [UnityTransport](xref:Unity.Netcode.Transports.UTP.UnityTransport) implementation for easy transport integration with Netcode.
 
-UNet is a deprecated solution that is no longer supported after Unity 2022.2. Unity Transport Package is the default transport for Netcode for GameObjects. We recommend transitioning to Unity Transport as soon as possible.
+## Single player transport
 
-### Community Transports or Writing Your Own
+Netcode also provides a [single player transport](./singleplayer.md) that allows for easy switching between multiplayer and single player configurations.
+
+## Community Transports or Writing Your Own
 
 You can use any of the community contributed custom transport implementations or write your own.
 

--- a/com.unity.netcode.gameobjects/Documentation~/command-line-arguments.md
+++ b/com.unity.netcode.gameobjects/Documentation~/command-line-arguments.md
@@ -23,40 +23,22 @@ You can define additional custom command-line arguments and retrieve them throug
 ## Example
 
 The following code shows you an example of defining and then reading a custom command-line argument.
-```
-private const string k_OverrideArg = "-argName";
 
-private bool ParseCommandLineOptions(out string command)
-{
-    if (CommandLineOptions.Instance.GetArg(k_OverrideArg) is string argValue)
-    {
-        command = argValue;
-        return true;
-    }
-    command = default;
-    return false;
-}
-```
+[!code-cs[](../Tests/Runtime/DocumentationCodeSamples/Configuration/CommandLineOptionsDocsTests.cs#DefineAndRead)]
 
 Usage example:
 
-```
-if (ParseCommandLineOptions(out var command))
-{
-    // Your logic here
-}
-```
+[!code-cs[](../Tests/Runtime/DocumentationCodeSamples/Configuration/CommandLineOptionsDocsTests.cs#Usage)]
 
 ## Override connection data
 
-If you want to ignore the connection port provided through command-line arguments, you can override it by using the optional `forceOverride` parameter in:
+By default, the command line provided connection port and ip address take precedence over runtime configured values when using the [Unity transport](./advanced-topics/transports.md#unity-transport-package).
 
-```
-UnityTransport.SetConnectionData(string ip, ushort port, string listenAddress, bool forceOverride);
-```
+> [!NOTE]
+> When the [Unity dedicated server package](https://docs.unity3d.com/Documentation/Manual/dedicated-server.html) is installed, Unity transport will use the port and ip address provided by the dedicated server package.
 
-Setting `forceOverride` to `true` ensures that the values you pass to `SetConnectionData` override any values specified via command-line arguments.
+If you want to ignore the connection port provided through command-line arguments, you can override it by setting the `forceOverrideCommandLineArgs` parameter of UnityTransport's [`SetConnectionData`](xref:Unity.Netcode.Transports.UTP.UnityTransport.SetConnectionData(System.Boolean,System.String,System.UInt16,System.String)). Setting `forceOverrideCommandLineArgs` to `true` ensures that the values you pass to `SetConnectionData` will override any values specified via command-line arguments.
 
 ## Additional resources
 
-- [Command-line arguments in the Unity Manual](https://docs.unity3d.com/6000.2/Documentation/Manual/CommandLineArguments.html)
+- [Command-line arguments in the Unity Manual](https://docs.unity3d.com/Documentation/Manual/CommandLineArguments.html)

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -2285,6 +2285,43 @@ namespace Unity.Netcode.GameObjects.Editor.CodeGen
                 {
                     // ServerRpc
 
+                    // Require ownership check.
+                    // Only the owner of an object can send a ServerRPC
+                    {
+                        var roReturnInstr = processor.Create(OpCodes.Ret);
+                        var roLastInstr = processor.Create(OpCodes.Nop);
+
+                        // if (this.OwnerClientId != networkManager.LocalClientId) { ... } return;
+                        instructions.Add(processor.Create(OpCodes.Ldarg_0));
+                        instructions.Add(processor.Create(OpCodes.Call, m_NetworkBehaviour_getOwnerClientId_MethodRef));
+                        instructions.Add(processor.Create(OpCodes.Ldloc, netManLocIdx));
+                        instructions.Add(processor.Create(OpCodes.Callvirt, m_NetworkManager_getLocalClientId_MethodRef));
+                        instructions.Add(processor.Create(OpCodes.Ceq));
+                        instructions.Add(processor.Create(OpCodes.Ldc_I4, 0));
+                        instructions.Add(processor.Create(OpCodes.Ceq));
+                        instructions.Add(processor.Create(OpCodes.Brfalse, roLastInstr));
+
+                        var logNextInstr = processor.Create(OpCodes.Nop);
+
+                        // if (LogLevel.Normal > networkManager.LogLevel)
+                        instructions.Add(processor.Create(OpCodes.Ldloc, netManLocIdx));
+                        instructions.Add(processor.Create(OpCodes.Ldfld, m_NetworkManager_LogLevel_FieldRef));
+                        instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)LogLevel.Normal));
+                        instructions.Add(processor.Create(OpCodes.Cgt));
+                        instructions.Add(processor.Create(OpCodes.Ldc_I4, 0));
+                        instructions.Add(processor.Create(OpCodes.Ceq));
+                        instructions.Add(processor.Create(OpCodes.Brfalse, logNextInstr));
+
+                        // Debug.LogError(...);
+                        instructions.Add(processor.Create(OpCodes.Ldstr, "Only the owner can invoke a ServerRpc!"));
+                        instructions.Add(processor.Create(OpCodes.Call, m_Debug_LogError_MethodRef));
+
+                        instructions.Add(logNextInstr);
+
+                        instructions.Add(roReturnInstr);
+                        instructions.Add(roLastInstr);
+                    }
+
                     // var bufferWriter = __beginSendServerRpc(rpcMethodId, serverRpcParams, rpcDelivery);
                     instructions.Add(processor.Create(OpCodes.Ldarg_0));
 
@@ -2891,6 +2928,8 @@ namespace Unity.Netcode.GameObjects.Editor.CodeGen
 
             var processor = rpcHandler.Body.GetILProcessor();
 
+            var isServerRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.ServerRpcAttribute_FullName;
+
             rpcHandler.Body.InitLocals = true;
             // NetworkManager networkManager;
             rpcHandler.Body.Variables.Add(new VariableDefinition(m_NetworkManager_TypeRef));
@@ -2914,6 +2953,44 @@ namespace Unity.Netcode.GameObjects.Editor.CodeGen
 
                 processor.Append(returnInstr);
                 processor.Append(lastInstr);
+            }
+
+            if (isServerRpc)
+            {
+                var roReturnInstr = processor.Create(OpCodes.Ret);
+                var roLastInstr = processor.Create(OpCodes.Nop);
+
+                // if (rpcParams.Server.Receive.SenderClientId != target.OwnerClientId) { ... } return;
+                processor.Emit(OpCodes.Ldarg_2);
+                processor.Emit(OpCodes.Ldfld, m_RpcParams_Server_FieldRef);
+                processor.Emit(OpCodes.Ldfld, m_ServerRpcParams_Receive_FieldRef);
+                processor.Emit(OpCodes.Ldfld, m_ServerRpcParams_Receive_SenderClientId_FieldRef);
+                processor.Emit(OpCodes.Ldarg_0);
+                processor.Emit(OpCodes.Call, m_NetworkBehaviour_getOwnerClientId_MethodRef);
+                processor.Emit(OpCodes.Ceq);
+                processor.Emit(OpCodes.Ldc_I4, 0);
+                processor.Emit(OpCodes.Ceq);
+                processor.Emit(OpCodes.Brfalse, roLastInstr);
+
+                var logNextInstr = processor.Create(OpCodes.Nop);
+
+                // if (LogLevel.Normal > networkManager.LogLevel)
+                processor.Emit(OpCodes.Ldloc, netManLocIdx);
+                processor.Emit(OpCodes.Ldfld, m_NetworkManager_LogLevel_FieldRef);
+                processor.Emit(OpCodes.Ldc_I4, (int)LogLevel.Normal);
+                processor.Emit(OpCodes.Cgt);
+                processor.Emit(OpCodes.Ldc_I4, 0);
+                processor.Emit(OpCodes.Ceq);
+                processor.Emit(OpCodes.Brfalse, logNextInstr);
+
+                // Debug.LogError(...);
+                processor.Emit(OpCodes.Ldstr, "Only the owner can invoke a ServerRpc!");
+                processor.Emit(OpCodes.Call, m_Debug_LogError_MethodRef);
+
+                processor.Append(logNextInstr);
+
+                processor.Append(roReturnInstr);
+                processor.Append(roLastInstr);
             }
 
             // read method parameters from stream

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -617,10 +617,7 @@ namespace Unity.Netcode.GameObjects.Editor.CodeGen
         private const string k_RpcAttribute_Delivery = nameof(RpcAttribute.Delivery);
         private const string k_RpcAttribute_InvokePermission = nameof(RpcAttribute.InvokePermission);
 
-#pragma warning disable CS0618 // Type or member is obsolete
-        // Need to ignore the obsolete warning as the obsolete behaviour still needs to work
-        private const string k_ServerRpcAttribute_RequireOwnership = nameof(ServerRpcAttribute.RequireOwnership);
-#pragma warning restore CS0618 // Type or member is obsolete
+        private const string k_ServerRpcAttribute_RequireOwnership = "RequireOwnership";
 
         private const string k_RpcParams_Server = nameof(__RpcParams.Server);
         private const string k_RpcParams_Client = nameof(__RpcParams.Client);

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -2891,14 +2891,6 @@ namespace Unity.Netcode.GameObjects.Editor.CodeGen
 
             var processor = rpcHandler.Body.GetILProcessor();
 
-            var isServerRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.ServerRpcAttribute_FullName;
-            foreach (var attrField in rpcAttribute.Fields)
-            {
-                switch (attrField.Name)
-                {
-                }
-            }
-
             rpcHandler.Body.InitLocals = true;
             // NetworkManager networkManager;
             rpcHandler.Body.Variables.Add(new VariableDefinition(m_NetworkManager_TypeRef));

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/NetworkBehaviourILPP.cs
@@ -617,8 +617,6 @@ namespace Unity.Netcode.GameObjects.Editor.CodeGen
         private const string k_RpcAttribute_Delivery = nameof(RpcAttribute.Delivery);
         private const string k_RpcAttribute_InvokePermission = nameof(RpcAttribute.InvokePermission);
 
-        private const string k_ServerRpcAttribute_RequireOwnership = "RequireOwnership";
-
         private const string k_RpcParams_Server = nameof(__RpcParams.Server);
         private const string k_RpcParams_Client = nameof(__RpcParams.Client);
         private const string k_RpcParams_Ext = nameof(__RpcParams.Ext);
@@ -1499,10 +1497,6 @@ namespace Unity.Netcode.GameObjects.Editor.CodeGen
                     {
                         switch (attrField.Name)
                         {
-                            case k_ServerRpcAttribute_RequireOwnership:
-                                var requireOwnership = attrField.Argument.Type == rpcHandler.Module.TypeSystem.Boolean && (bool)attrField.Argument.Value;
-                                invokePermission = requireOwnership ? RpcInvokePermission.Owner : RpcInvokePermission.Everyone;
-                                break;
                             case k_RpcAttribute_InvokePermission:
                                 invokePermission = (RpcInvokePermission)attrField.Argument.Value;
                                 break;
@@ -1688,28 +1682,6 @@ namespace Unity.Netcode.GameObjects.Editor.CodeGen
 
                 return null;
             }
-
-            bool hasInvokePermission = false, hasRequireOwnership = false;
-
-            foreach (var argument in rpcAttribute.Fields)
-            {
-                switch (argument.Name)
-                {
-                    case k_ServerRpcAttribute_RequireOwnership:
-                        hasRequireOwnership = true;
-                        break;
-                    case k_RpcAttribute_InvokePermission:
-                        hasInvokePermission = true;
-                        break;
-                }
-            }
-
-            if (hasInvokePermission && hasRequireOwnership)
-            {
-                m_Diagnostics.AddError($"{methodDefinition.Name} cannot declare both RequireOwnership and InvokePermission!");
-                return null;
-            }
-
 
             // Checks for IsSerializable are moved to later as the check is now done by dynamically seeing if any valid
             // serializer OR extension method exists for it.
@@ -2177,7 +2149,6 @@ namespace Unity.Netcode.GameObjects.Editor.CodeGen
             var isServerRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.ServerRpcAttribute_FullName;
             var isClientRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.ClientRpcAttribute_FullName;
             var isGenericRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.RpcAttribute_FullName;
-            var requireOwnership = true; // default value MUST be == `ServerRpcAttribute.RequireOwnership`
             var rpcDelivery = RpcDelivery.Reliable; // default value MUST be == `RpcAttribute.Delivery`
             var defaultTarget = SendTo.Everyone;
             var allowTargetOverride = false;
@@ -2192,9 +2163,6 @@ namespace Unity.Netcode.GameObjects.Editor.CodeGen
                 {
                     case k_RpcAttribute_Delivery:
                         rpcDelivery = (RpcDelivery)attrField.Argument.Value;
-                        break;
-                    case k_ServerRpcAttribute_RequireOwnership:
-                        requireOwnership = attrField.Argument.Type == typeSystem.Boolean && (bool)attrField.Argument.Value;
                         break;
                     case nameof(RpcAttribute.AllowTargetOverride):
                         allowTargetOverride = attrField.Argument.Type == typeSystem.Boolean && (bool)attrField.Argument.Value;
@@ -2316,42 +2284,6 @@ namespace Unity.Netcode.GameObjects.Editor.CodeGen
                 if (isServerRpc)
                 {
                     // ServerRpc
-
-                    if (requireOwnership)
-                    {
-                        var roReturnInstr = processor.Create(OpCodes.Ret);
-                        var roLastInstr = processor.Create(OpCodes.Nop);
-
-                        // if (this.OwnerClientId != networkManager.LocalClientId) { ... } return;
-                        instructions.Add(processor.Create(OpCodes.Ldarg_0));
-                        instructions.Add(processor.Create(OpCodes.Call, m_NetworkBehaviour_getOwnerClientId_MethodRef));
-                        instructions.Add(processor.Create(OpCodes.Ldloc, netManLocIdx));
-                        instructions.Add(processor.Create(OpCodes.Callvirt, m_NetworkManager_getLocalClientId_MethodRef));
-                        instructions.Add(processor.Create(OpCodes.Ceq));
-                        instructions.Add(processor.Create(OpCodes.Ldc_I4, 0));
-                        instructions.Add(processor.Create(OpCodes.Ceq));
-                        instructions.Add(processor.Create(OpCodes.Brfalse, roLastInstr));
-
-                        var logNextInstr = processor.Create(OpCodes.Nop);
-
-                        // if (LogLevel.Normal > networkManager.LogLevel)
-                        instructions.Add(processor.Create(OpCodes.Ldloc, netManLocIdx));
-                        instructions.Add(processor.Create(OpCodes.Ldfld, m_NetworkManager_LogLevel_FieldRef));
-                        instructions.Add(processor.Create(OpCodes.Ldc_I4, (int)LogLevel.Normal));
-                        instructions.Add(processor.Create(OpCodes.Cgt));
-                        instructions.Add(processor.Create(OpCodes.Ldc_I4, 0));
-                        instructions.Add(processor.Create(OpCodes.Ceq));
-                        instructions.Add(processor.Create(OpCodes.Brfalse, logNextInstr));
-
-                        // Debug.LogError(...);
-                        instructions.Add(processor.Create(OpCodes.Ldstr, "Only the owner can invoke a ServerRpc that requires ownership!"));
-                        instructions.Add(processor.Create(OpCodes.Call, m_Debug_LogError_MethodRef));
-
-                        instructions.Add(logNextInstr);
-
-                        instructions.Add(roReturnInstr);
-                        instructions.Add(roLastInstr);
-                    }
 
                     // var bufferWriter = __beginSendServerRpc(rpcMethodId, serverRpcParams, rpcDelivery);
                     instructions.Add(processor.Create(OpCodes.Ldarg_0));
@@ -2960,14 +2892,10 @@ namespace Unity.Netcode.GameObjects.Editor.CodeGen
             var processor = rpcHandler.Body.GetILProcessor();
 
             var isServerRpc = rpcAttribute.AttributeType.FullName == CodeGenHelpers.ServerRpcAttribute_FullName;
-            var requireOwnership = true; // default value MUST be == `ServerRpcAttribute.RequireOwnership`
             foreach (var attrField in rpcAttribute.Fields)
             {
                 switch (attrField.Name)
                 {
-                    case k_ServerRpcAttribute_RequireOwnership:
-                        requireOwnership = attrField.Argument.Type == typeSystem.Boolean && (bool)attrField.Argument.Value;
-                        break;
                 }
             }
 
@@ -2994,44 +2922,6 @@ namespace Unity.Netcode.GameObjects.Editor.CodeGen
 
                 processor.Append(returnInstr);
                 processor.Append(lastInstr);
-            }
-
-            if (isServerRpc && requireOwnership)
-            {
-                var roReturnInstr = processor.Create(OpCodes.Ret);
-                var roLastInstr = processor.Create(OpCodes.Nop);
-
-                // if (rpcParams.Server.Receive.SenderClientId != target.OwnerClientId) { ... } return;
-                processor.Emit(OpCodes.Ldarg_2);
-                processor.Emit(OpCodes.Ldfld, m_RpcParams_Server_FieldRef);
-                processor.Emit(OpCodes.Ldfld, m_ServerRpcParams_Receive_FieldRef);
-                processor.Emit(OpCodes.Ldfld, m_ServerRpcParams_Receive_SenderClientId_FieldRef);
-                processor.Emit(OpCodes.Ldarg_0);
-                processor.Emit(OpCodes.Call, m_NetworkBehaviour_getOwnerClientId_MethodRef);
-                processor.Emit(OpCodes.Ceq);
-                processor.Emit(OpCodes.Ldc_I4, 0);
-                processor.Emit(OpCodes.Ceq);
-                processor.Emit(OpCodes.Brfalse, roLastInstr);
-
-                var logNextInstr = processor.Create(OpCodes.Nop);
-
-                // if (LogLevel.Normal > networkManager.LogLevel)
-                processor.Emit(OpCodes.Ldloc, netManLocIdx);
-                processor.Emit(OpCodes.Ldfld, m_NetworkManager_LogLevel_FieldRef);
-                processor.Emit(OpCodes.Ldc_I4, (int)LogLevel.Normal);
-                processor.Emit(OpCodes.Cgt);
-                processor.Emit(OpCodes.Ldc_I4, 0);
-                processor.Emit(OpCodes.Ceq);
-                processor.Emit(OpCodes.Brfalse, logNextInstr);
-
-                // Debug.LogError(...);
-                processor.Emit(OpCodes.Ldstr, "Only the owner can invoke a ServerRpc that requires ownership!");
-                processor.Emit(OpCodes.Call, m_Debug_LogError_MethodRef);
-
-                processor.Append(logNextInstr);
-
-                processor.Append(roReturnInstr);
-                processor.Append(roLastInstr);
             }
 
             // read method parameters from stream

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
@@ -47,9 +47,6 @@ namespace Unity.Netcode.GameObjects.Editor.CodeGen
 
                     switch (typeDefinition.Name)
                     {
-                        case nameof(NetworkManager):
-                            ProcessNetworkManager(typeDefinition, compiledAssembly.Defines);
-                            break;
                         case nameof(NetworkBehaviour):
                             ProcessNetworkBehaviour(typeDefinition);
                             break;
@@ -88,38 +85,6 @@ namespace Unity.Netcode.GameObjects.Editor.CodeGen
             assemblyDefinition.Write(pe, writerParameters);
 
             return new ILPostProcessResult(new InMemoryAssembly(pe.ToArray(), pdb.ToArray()), m_Diagnostics);
-        }
-
-        // TODO: Deprecate...
-        // This is changing accessibility for values that are no longer used, but since our validator runs
-        // after ILPP and sees those values as public, they cannot be removed until a major version change.
-        private void ProcessNetworkManager(TypeDefinition typeDefinition, string[] assemblyDefines)
-        {
-            foreach (var fieldDefinition in typeDefinition.Fields)
-            {
-                if (fieldDefinition.Name == "__rpc_func_table")
-                {
-                    fieldDefinition.IsPublic = true;
-                }
-
-                if (fieldDefinition.Name == "RpcReceiveHandler")
-                {
-                    fieldDefinition.IsPublic = true;
-                }
-
-                if (fieldDefinition.Name == "__rpc_name_table")
-                {
-                    fieldDefinition.IsPublic = true;
-                }
-            }
-
-            foreach (var nestedTypeDefinition in typeDefinition.NestedTypes)
-            {
-                if (nestedTypeDefinition.Name == "RpcReceiveHandler")
-                {
-                    nestedTypeDefinition.IsNestedPublic = true;
-                }
-            }
         }
 
         private void ProcessNetworkBehaviour(TypeDefinition typeDefinition)

--- a/com.unity.netcode.gameobjects/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
+++ b/com.unity.netcode.gameobjects/Editor/CodeGen/RuntimeAccessModifiersILPP.cs
@@ -97,23 +97,17 @@ namespace Unity.Netcode.GameObjects.Editor.CodeGen
         {
             foreach (var fieldDefinition in typeDefinition.Fields)
             {
-#pragma warning disable CS0618 // Type or member is obsolete
-                if (fieldDefinition.Name == nameof(NetworkManager.__rpc_func_table))
-#pragma warning restore CS0618 // Type or member is obsolete
+                if (fieldDefinition.Name == "__rpc_func_table")
                 {
                     fieldDefinition.IsPublic = true;
                 }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-                if (fieldDefinition.Name == nameof(NetworkManager.RpcReceiveHandler))
-#pragma warning restore CS0618 // Type or member is obsolete
+                if (fieldDefinition.Name == "RpcReceiveHandler")
                 {
                     fieldDefinition.IsPublic = true;
                 }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-                if (fieldDefinition.Name == nameof(NetworkManager.__rpc_name_table))
-#pragma warning restore CS0618 // Type or member is obsolete
+                if (fieldDefinition.Name == "__rpc_name_table")
                 {
                     fieldDefinition.IsPublic = true;
                 }
@@ -121,9 +115,7 @@ namespace Unity.Netcode.GameObjects.Editor.CodeGen
 
             foreach (var nestedTypeDefinition in typeDefinition.NestedTypes)
             {
-#pragma warning disable CS0618 // Type or member is obsolete
-                if (nestedTypeDefinition.Name == nameof(NetworkManager.RpcReceiveHandler))
-#pragma warning restore CS0618 // Type or member is obsolete
+                if (nestedTypeDefinition.Name == "RpcReceiveHandler")
                 {
                     nestedTypeDefinition.IsNestedPublic = true;
                 }

--- a/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
@@ -101,7 +101,6 @@ namespace Unity.Netcode.GameObjects.Editor
                 EditorGUILayout.Toggle(nameof(NetworkObject.IsOwner), m_NetworkObject.IsOwner);
                 EditorGUILayout.Toggle(nameof(NetworkObject.IsOwnedByServer), m_NetworkObject.IsOwnedByServer);
                 EditorGUILayout.Toggle(nameof(NetworkObject.IsPlayerObject), m_NetworkObject.IsPlayerObject);
-                EditorGUILayout.Toggle("IsSceneObject", m_NetworkObject.InScenePlaced);
                 EditorGUILayout.Toggle(nameof(NetworkObject.DestroyWithScene), m_NetworkObject.DestroyWithScene);
                 EditorGUILayout.TextField(nameof(NetworkObject.NetworkManager), m_NetworkObject.NetworkManager == null ? "null" : m_NetworkObject.NetworkManager.gameObject.name);
                 GUI.enabled = guiEnabled;

--- a/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
+++ b/com.unity.netcode.gameobjects/Editor/NetworkObjectEditor.cs
@@ -101,10 +101,7 @@ namespace Unity.Netcode.GameObjects.Editor
                 EditorGUILayout.Toggle(nameof(NetworkObject.IsOwner), m_NetworkObject.IsOwner);
                 EditorGUILayout.Toggle(nameof(NetworkObject.IsOwnedByServer), m_NetworkObject.IsOwnedByServer);
                 EditorGUILayout.Toggle(nameof(NetworkObject.IsPlayerObject), m_NetworkObject.IsPlayerObject);
-#pragma warning disable CS0618 // Type or member is obsolete
-                // TODO-3.x: Update name in 3.x branch
-                EditorGUILayout.Toggle(nameof(NetworkObject.IsSceneObject), m_NetworkObject.InScenePlaced);
-#pragma warning restore CS0618 // Type or member is obsolete
+                EditorGUILayout.Toggle("IsSceneObject", m_NetworkObject.InScenePlaced);
                 EditorGUILayout.Toggle(nameof(NetworkObject.DestroyWithScene), m_NetworkObject.DestroyWithScene);
                 EditorGUILayout.TextField(nameof(NetworkObject.NetworkManager), m_NetworkObject.NetworkManager == null ? "null" : m_NetworkObject.NetworkManager.gameObject.name);
                 GUI.enabled = guiEnabled;

--- a/com.unity.netcode.gameobjects/Runtime/Components/Interpolator/BufferedLinearInterpolator.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/Interpolator/BufferedLinearInterpolator.cs
@@ -59,28 +59,28 @@ namespace Unity.Netcode
         /// <remarks>
         /// This is replaced by the <see cref="m_BufferQueue"/> of type <see cref="Queue{T}"/>.
         /// </remarks>
-        [Obsolete("This list is no longer used and will be deprecated.", false)]
+        [Obsolete("This list is no longer used and will be deprecated.", true)]
         protected internal readonly List<BufferedItem> m_Buffer = new List<BufferedItem>();
 
         /// <summary>
         /// ** Deprecating **
         /// The starting value of type <see cref="T"/> to interpolate from.
         /// </summary>
-        [Obsolete("This property will be deprecated.", false)]
+        [Obsolete("This property will be deprecated.", true)]
         protected internal T m_InterpStartValue;
 
         /// <summary>
         /// ** Deprecating **
         /// The current value of type <see cref="T"/>.
         /// </summary>
-        [Obsolete("This property will be deprecated.", false)]
+        [Obsolete("This property will be deprecated.", true)]
         protected internal T m_CurrentInterpValue;
 
         /// <summary>
         /// ** Deprecating **
         /// The end (or target) value of type <see cref="T"/> to interpolate towards.
         /// </summary>
-        [Obsolete("This property will be deprecated.", false)]
+        [Obsolete("This property will be deprecated.", true)]
         protected internal T m_InterpEndValue;
         #endregion
 
@@ -651,7 +651,7 @@ namespace Unity.Netcode
         /// <param name="deltaTime">time since call</param>
         /// <param name="serverTime">current server time</param>
         /// <returns>The newly interpolated value of type 'T'</returns>
-        [Obsolete("This method is being deprecated due to it being only used for internal testing purposes.", false)]
+        [Obsolete("This method is being deprecated due to it being only used for internal testing purposes.", true)]
         public T Update(float deltaTime, NetworkTime serverTime)
         {
             return UpdateInternal(deltaTime, serverTime);

--- a/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Components/NetworkTransform.cs
@@ -3861,17 +3861,6 @@ namespace Unity.Netcode.Components
 
         #region PARENTING AND OWNERSHIP
         /// <inheritdoc/>
-        public override void OnLostOwnership()
-        {
-            base.OnLostOwnership();
-        }
-
-        /// <inheritdoc/>
-        public override void OnGainedOwnership()
-        {
-            base.OnGainedOwnership();
-        }
-        /// <inheritdoc/>
         protected override void OnOwnershipChanged(ulong previous, ulong current)
         {
             // If we were the previous owner or the newly assigned owner then reinitialize

--- a/com.unity.netcode.gameobjects/Runtime/Configuration/CommandLineOptions.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Configuration/CommandLineOptions.cs
@@ -12,7 +12,7 @@ namespace Unity.Netcode
         /// <summary>
         /// Command-line options singleton
         /// </summary>
-        [Obsolete("Not used anymore replaced by TryGetArg")]
+        [Obsolete("Not used anymore replaced by TryGetArg", true)]
         public static CommandLineOptions Instance
         {
             get
@@ -38,7 +38,7 @@ namespace Unity.Netcode
         /// </summary>
         /// <param name="arg">The name of the argument</param>
         /// <returns><see cref="string"/>Value of the command line argument passed in.</returns>
-        [Obsolete("Not used anymore replaced by TryGetArg")]
+        [Obsolete("Not used anymore replaced by TryGetArg", true)]
         public string GetArg(string arg)
         {
             var argIndex = k_CommandLineArguments.IndexOf(arg);

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -1026,7 +1026,6 @@ namespace Unity.Netcode
                     if (NetworkManager.SpawnManager.AuthorityLocalSpawn(
                         playerObject,
                         NetworkManager.SpawnManager.GetNetworkObjectId(),
-                        sceneObject: false,
                         playerObject: true,
                         ownerClientId,
                         destroyWithScene: false))
@@ -1189,7 +1188,6 @@ namespace Unity.Netcode
                 return;
             }
 
-            networkObject.IsSceneObjectInternal = false;
             networkObject.NetworkManagerOwner = NetworkManager;
             networkObject.SpawnAsPlayerObject(ownerId, networkObject.DestroyWithScene);
         }

--- a/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Connection/NetworkConnectionManager.cs
@@ -1189,11 +1189,7 @@ namespace Unity.Netcode
                 return;
             }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            // Obsolete with warning means we need the underlying behaviour to keep existing
-            // TODO: remove in the 3.x branch
-            networkObject.SetSceneObjectStatus(false);
-#pragma warning restore CS0618 // Type or member is obsolete
+            networkObject.IsSceneObjectInternal = false;
             networkObject.NetworkManagerOwner = NetworkManager;
             networkObject.SpawnAsPlayerObject(ownerId, networkObject.DestroyWithScene);
         }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkBehaviour.cs
@@ -335,11 +335,7 @@ namespace Unity.Netcode
                 throw new RpcException("This RPC can only be sent by the server.");
             }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            var requireOwnership = attributeParams.RequireOwnership;
-#pragma warning restore CS0618 // Type or member is obsolete
-
-            if ((requireOwnership || attributeParams.InvokePermission == RpcInvokePermission.Owner) && !IsOwner)
+            if (attributeParams.InvokePermission == RpcInvokePermission.Owner && !IsOwner)
             {
                 throw new RpcException("This RPC can only be sent by its owner.");
             }

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -65,25 +65,6 @@ namespace Unity.Netcode
         public bool NetworkManagerExpanded;
 #endif
 
-        // TODO: Deprecate...
-        // The following internal values are not used, but because ILPP makes them public in the assembly, they cannot
-        // be removed thanks to our semver validation.
-#pragma warning disable IDE1006 // disable naming rule violation check
-
-        // RuntimeAccessModifiersILPP will make this `public`
-        [Obsolete("This field is no longer used and will be removed in a future version.", true)]
-        internal delegate void RpcReceiveHandler(NetworkBehaviour behaviour, FastBufferReader reader, __RpcParams parameters);
-
-        // RuntimeAccessModifiersILPP will make this `public`
-        [Obsolete("This field is no longer used and will be removed in a future version.", true)]
-        internal static readonly Dictionary<uint, RpcReceiveHandler> __rpc_func_table = new Dictionary<uint, RpcReceiveHandler>();
-
-        // RuntimeAccessModifiersILPP will make this `public` (legacy table should be removed in v3.x.x)
-        [Obsolete("This field is no longer used and will be removed in a future version.", true)]
-        internal static readonly Dictionary<uint, string> __rpc_name_table = new Dictionary<uint, string>();
-
-#pragma warning restore IDE1006 // restore naming rule violation check
-
 #if DEBUG
         private static List<Type> s_SerializedType = new List<Type>();
         // This is used to control the serialized type not optimized messaging for integration test purposes

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkManager.cs
@@ -71,15 +71,15 @@ namespace Unity.Netcode
 #pragma warning disable IDE1006 // disable naming rule violation check
 
         // RuntimeAccessModifiersILPP will make this `public`
-        [Obsolete("This field is no longer used and will be removed in a future version.")]
+        [Obsolete("This field is no longer used and will be removed in a future version.", true)]
         internal delegate void RpcReceiveHandler(NetworkBehaviour behaviour, FastBufferReader reader, __RpcParams parameters);
 
         // RuntimeAccessModifiersILPP will make this `public`
-        [Obsolete("This field is no longer used and will be removed in a future version.")]
+        [Obsolete("This field is no longer used and will be removed in a future version.", true)]
         internal static readonly Dictionary<uint, RpcReceiveHandler> __rpc_func_table = new Dictionary<uint, RpcReceiveHandler>();
 
         // RuntimeAccessModifiersILPP will make this `public` (legacy table should be removed in v3.x.x)
-        [Obsolete("This field is no longer used and will be removed in a future version.")]
+        [Obsolete("This field is no longer used and will be removed in a future version.", true)]
         internal static readonly Dictionary<uint, string> __rpc_name_table = new Dictionary<uint, string>();
 
 #pragma warning restore IDE1006 // restore naming rule violation check

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -347,8 +347,6 @@ namespace Unity.Netcode
                     }
                 }
 
-                IsSceneObjectInternal = true;
-
                 // We go ahead and set this for "typical in-scene placed" usage patterns so this is serialized
                 InScenePlaced = true;
 
@@ -1319,11 +1317,8 @@ namespace Unity.Netcode
         /// This method is marked for deprecation.<br />
         /// Use <see cref="InScenePlaced"/> instead.
         /// </remarks>
-        internal bool? IsSceneObjectInternal { get; set; }
-
         [Obsolete("Use InScenePlaced instead", true)]
-        public bool? IsSceneObject { get => IsSceneObjectInternal; internal set => IsSceneObjectInternal = value; }
-
+        public bool? IsSceneObject { get; internal set; }
 
         /// <summary>
         /// The serialized value.
@@ -1362,7 +1357,6 @@ namespace Unity.Netcode
         [Obsolete("SetSceneObjectStatus is now calculated during the build.", true)]
         public void SetSceneObjectStatus(bool isSceneObject = false)
         {
-            IsSceneObjectInternal = isSceneObject;
         }
 
         /// <summary>
@@ -1988,8 +1982,6 @@ namespace Unity.Netcode
                 return;
             }
 
-            var legacyIsSceneObject = IsSceneObjectInternal.HasValue && IsSceneObjectInternal.Value;
-
             // If the initial state of the GameObject was disabled and InScenePlaced is marked,
             // then spawn it as in-scene placed.
             // Otherwise:
@@ -2006,7 +1998,7 @@ namespace Unity.Netcode
                 InScenePlaced = false;
             }
 
-            if (!NetworkManagerOwner.SpawnManager.AuthorityLocalSpawn(this, NetworkManagerOwner.SpawnManager.GetNetworkObjectId(), legacyIsSceneObject, playerObject, ownerClientId, destroyWithScene))
+            if (!NetworkManagerOwner.SpawnManager.AuthorityLocalSpawn(this, NetworkManagerOwner.SpawnManager.GetNetworkObjectId(), playerObject, ownerClientId, destroyWithScene))
             {
                 if (NetworkManagerOwner.LogLevel <= LogLevel.Normal)
                 {

--- a/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Core/NetworkObject.cs
@@ -347,11 +347,7 @@ namespace Unity.Netcode
                     }
                 }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-                // Obsolete with warning means we need the underlying behaviour to keep existing
-                // TODO-3.x: remove in the 3.x branch
-                SetSceneObjectStatus(true);
-#pragma warning restore CS0618 // Type or member is obsolete
+                IsSceneObjectInternal = true;
 
                 // We go ahead and set this for "typical in-scene placed" usage patterns so this is serialized
                 InScenePlaced = true;
@@ -1323,8 +1319,10 @@ namespace Unity.Netcode
         /// This method is marked for deprecation.<br />
         /// Use <see cref="InScenePlaced"/> instead.
         /// </remarks>
-        [Obsolete("Use InScenePlaced instead")]
-        public bool? IsSceneObject { get; internal set; }
+        internal bool? IsSceneObjectInternal { get; set; }
+
+        [Obsolete("Use InScenePlaced instead", true)]
+        public bool? IsSceneObject { get => IsSceneObjectInternal; internal set => IsSceneObjectInternal = value; }
 
 
         /// <summary>
@@ -1361,10 +1359,10 @@ namespace Unity.Netcode
         /// </summary>
         /// <remarks>Only use this when using custom scene loading</remarks>
         /// <param name="isSceneObject">When true, marks this as a scene-instantiated object; when false, marks it as runtime-instantiated</param>
-        [Obsolete("SetSceneObjectStatus is now calculated during the build.")]
+        [Obsolete("SetSceneObjectStatus is now calculated during the build.", true)]
         public void SetSceneObjectStatus(bool isSceneObject = false)
         {
-            IsSceneObject = isSceneObject;
+            IsSceneObjectInternal = isSceneObject;
         }
 
         /// <summary>
@@ -1990,11 +1988,7 @@ namespace Unity.Netcode
                 return;
             }
 
-            // Calculate the legacy IsSceneObject value as the public field is obsolete with warning
-            // We can't break the public behavior of the field.
-#pragma warning disable CS0618 // Type or member is obsolete
-            var legacyIsSceneObject = IsSceneObject.HasValue && IsSceneObject.Value;
-#pragma warning restore CS0618 // Type or member is obsolete
+            var legacyIsSceneObject = IsSceneObjectInternal.HasValue && IsSceneObjectInternal.Value;
 
             // If the initial state of the GameObject was disabled and InScenePlaced is marked,
             // then spawn it as in-scene placed.

--- a/com.unity.netcode.gameobjects/Runtime/Exceptions/NotListeningException.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Exceptions/NotListeningException.cs
@@ -5,7 +5,7 @@ namespace Unity.Netcode
     /// <summary>
     /// Exception thrown when the operation require NetworkManager to be listening.
     /// </summary>
-    [Obsolete("Not used anymore.")]
+    [Obsolete("Not used anymore.", true)]
     public class NotListeningException : Exception
     {
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcAttributes.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcAttributes.cs
@@ -62,7 +62,7 @@ namespace Unity.Netcode
             /// <remarks>
             /// Deprecated in favor of <see cref="InvokePermission"/>.
             /// </remarks>
-            [Obsolete("RequireOwnership is deprecated. Please use InvokePermission instead.")]
+            [Obsolete("RequireOwnership is deprecated. Please use InvokePermission instead."), true]
             public bool RequireOwnership;
 
             /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcAttributes.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcAttributes.cs
@@ -98,7 +98,7 @@ namespace Unity.Netcode
         /// <remarks>
         /// Deprecated in favor of <see cref="InvokePermission"/>.
         /// </remarks>
-        [Obsolete("RequireOwnership is deprecated. Please use InvokePermission = RpcInvokePermission.Owner or InvokePermission = RpcInvokePermission.Everyone instead.")]
+        [Obsolete("RequireOwnership is deprecated. Please use InvokePermission = RpcInvokePermission.Owner or InvokePermission = RpcInvokePermission.Everyone instead.", true)]
         public bool RequireOwnership;
 
         /// <summary>
@@ -151,7 +151,7 @@ namespace Unity.Netcode
         ///     [Rpc(SendTo.Server, InvokePermission = RpcInvokePermission.Owner)]
         /// </code>
         /// </remarks>
-        [Obsolete("ServerRpc with RequireOwnership is deprecated. Use [Rpc(SendTo.Server, InvokePermission = RpcInvokePermission.Everyone)] or [Rpc(SendTo.Server, InvokePermission = RpcInvokePermission.Owner)] instead.)]")]
+        [Obsolete("ServerRpc with RequireOwnership is deprecated. Use [Rpc(SendTo.Server, InvokePermission = RpcInvokePermission.Everyone)] or [Rpc(SendTo.Server, InvokePermission = RpcInvokePermission.Owner)] instead.)]", true)]
         public new bool RequireOwnership;
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Messaging/RpcAttributes.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Messaging/RpcAttributes.cs
@@ -62,7 +62,7 @@ namespace Unity.Netcode
             /// <remarks>
             /// Deprecated in favor of <see cref="InvokePermission"/>.
             /// </remarks>
-            [Obsolete("RequireOwnership is deprecated. Please use InvokePermission instead."), true]
+            [Obsolete("RequireOwnership is deprecated. Please use InvokePermission instead.", true)]
             public bool RequireOwnership;
 
             /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
+++ b/com.unity.netcode.gameobjects/Runtime/NetworkVariable/Collections/NetworkList.cs
@@ -686,7 +686,7 @@ namespace Unity.Netcode
         /// <summary>
         /// This method should not be used. It is left over from a previous interface
         /// </summary>
-        [Obsolete("This property is no longer used and will be removed in a future version.")]
+        [Obsolete("This property is no longer used and will be removed in a future version.", true)]
         public int LastModifiedTick => NetworkTickSystem.NoTick;
 
         /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/SceneManagement/NetworkSceneManager.cs
@@ -1842,7 +1842,7 @@ namespace Unity.Netcode
                     {
                         // All in-scene placed NetworkObjects default to being owned by the server
                         NetworkManager.SpawnManager.AuthorityLocalSpawn(keyValuePairBySceneHandle.Value,
-                            NetworkManager.SpawnManager.GetNetworkObjectId(), true, false, NetworkManager.LocalClientId, true);
+                            NetworkManager.SpawnManager.GetNetworkObjectId(), false, NetworkManager.LocalClientId, true);
                     }
                 }
             }

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -452,7 +452,7 @@ namespace Unity.Netcode
         /// </summary>
         /// <param name="perviousOwner">not used</param>
         /// <param name="newOwner">not used</param>
-        [Obsolete("This method is no longer used and will be removed in a future version.")]
+        [Obsolete("This method is no longer used and will be removed in a future version.", true)]
         protected virtual void InternalOnOwnershipChanged(ulong perviousOwner, ulong newOwner)
         {
 
@@ -1300,11 +1300,7 @@ namespace Unity.Netcode
                 return false;
             }
 
-#pragma warning disable CS0618 // Type or member is obsolete
-            // Obsolete with warning means we need the underlying behaviour to keep existing
-            // TODO: remove in the 3.x branch
-            networkObject.SetSceneObjectStatus(sceneObject);
-#pragma warning restore CS0618 // Type or member is obsolete
+            networkObject.IsSceneObjectInternal = sceneObject;
 
             networkObject.SetupOnSpawn(networkId, playerObject, ownerClientId, destroyWithScene);
 

--- a/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Spawning/NetworkSpawnManager.cs
@@ -1110,7 +1110,7 @@ namespace Unity.Netcode
         /// Distributed Authority:
         /// All clients can invoke this method.
         /// </summary>
-        internal bool AuthorityLocalSpawn([NotNull] NetworkObject networkObject, ulong networkId, bool sceneObject, bool playerObject, ulong ownerClientId, bool destroyWithScene)
+        internal bool AuthorityLocalSpawn([NotNull] NetworkObject networkObject, ulong networkId, bool playerObject, ulong ownerClientId, bool destroyWithScene)
         {
             if (networkObject.IsSpawned)
             {
@@ -1158,7 +1158,7 @@ namespace Unity.Netcode
             }
 
 
-            if (!SpawnNetworkObjectLocallyCommon(networkObject, networkId, sceneObject, playerObject, ownerClientId, destroyWithScene))
+            if (!SpawnNetworkObjectLocallyCommon(networkObject, networkId, playerObject, ownerClientId, destroyWithScene))
             {
                 if (NetworkManager.LogLevel <= LogLevel.Error)
                 {
@@ -1254,13 +1254,13 @@ namespace Unity.Netcode
             // being told we do not have a parent, then we want to clear the latest parent so it is not automatically
             // "re-parented" to the original parent. This can happen if not unloading the scene and the parenting of
             // the in-scene placed Networkobject changes several times over different sessions.
-            if (serializedObject.IsSceneObject && !serializedObject.HasParent && networkObject.GetNetworkParenting().HasValue)
+            if (networkObject.InScenePlaced && !serializedObject.HasParent && networkObject.GetNetworkParenting().HasValue)
             {
                 networkObject.ClearNetworkParenting();
             }
 
             // Do not invoke Pre spawn here (SynchronizeNetworkBehaviours needs to be invoked prior to this)
-            var succeeded = SpawnNetworkObjectLocallyCommon(networkObject, serializedObject.NetworkObjectId, serializedObject.IsSceneObject, serializedObject.IsPlayerObject, serializedObject.OwnerClientId, destroyWithScene);
+            var succeeded = SpawnNetworkObjectLocallyCommon(networkObject, serializedObject.NetworkObjectId, serializedObject.IsPlayerObject, serializedObject.OwnerClientId, destroyWithScene);
             if (!succeeded)
             {
                 // Don't need to log here as SpawnNetworkObjectLocallyCommon should log the specific error
@@ -1278,7 +1278,7 @@ namespace Unity.Netcode
         /// </summary>
         /// <returns>boolean indicating whether the spawn succeeded.</returns>
         //  Internal dev note: THIS IS A CATCH FOR OURSELVES. DON'T PULL OUT
-        internal bool SpawnNetworkObjectLocallyCommon(NetworkObject networkObject, ulong networkId, bool sceneObject, bool playerObject, ulong ownerClientId, bool destroyWithScene)
+        internal bool SpawnNetworkObjectLocallyCommon(NetworkObject networkObject, ulong networkId, bool playerObject, ulong ownerClientId, bool destroyWithScene)
         {
             // TODO: Replace the following checks with internal Netcode asserts
             // We want our tests to double check this without impacting users.
@@ -1299,8 +1299,6 @@ namespace Unity.Netcode
                 }
                 return false;
             }
-
-            networkObject.IsSceneObjectInternal = sceneObject;
 
             networkObject.SetupOnSpawn(networkId, playerObject, ownerClientId, destroyWithScene);
 
@@ -1657,7 +1655,7 @@ namespace Unity.Netcode
                         ownerId = NetworkManager.LocalClientId;
                     }
 
-                    if (AuthorityLocalSpawn(networkObject, GetNetworkObjectId(), true, false, ownerId, true))
+                    if (AuthorityLocalSpawn(networkObject, GetNetworkObjectId(), false, ownerId, true))
                     {
                         networkObjectsToSpawn.Add(networkObject);
                     }

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -345,7 +345,7 @@ namespace Unity.Netcode.Transports.UTP
         /// - packet drop rate (packet loss)
         /// </summary>
 
-        [Obsolete("DebugSimulator is no longer supported and has no effect. Use Network Simulator from the Multiplayer Tools package.", false)]
+        [Obsolete("DebugSimulator is no longer supported and has no effect. Use Network Simulator from the Multiplayer Tools package.", true)]
         [HideInInspector]
         public SimulatorParameters DebugSimulator = new SimulatorParameters
         {
@@ -966,7 +966,7 @@ namespace Unity.Netcode.Transports.UTP
         /// <param name="packetDelay">Packet delay in milliseconds.</param>
         /// <param name="packetJitter">Packet jitter in milliseconds.</param>
         /// <param name="dropRate">Packet drop percentage.</param>
-        [Obsolete("SetDebugSimulatorParameters is no longer supported and has no effect. Use Network Simulator from the Multiplayer Tools package.", false)]
+        [Obsolete("SetDebugSimulatorParameters is no longer supported and has no effect. Use Network Simulator from the Multiplayer Tools package.", true)]
         public void SetDebugSimulatorParameters(int packetDelay, int packetJitter, int dropRate)
         {
             if (m_Driver.IsCreated)

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -266,7 +266,7 @@ namespace Unity.Netcode.Transports.UTP
             /// is still handled correctly by NGO, but for this reason usage of this property is
             /// discouraged.
             /// </remarks>
-            [Obsolete("Use NetworkEndpoint.Parse on the Address field instead.")]
+            [Obsolete("Use NetworkEndpoint.Parse on the Address field instead.", true)]
             public NetworkEndpoint ServerEndPoint => ParseNetworkEndpoint(Address, Port);
 
             /// <summary>

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -313,6 +313,7 @@ namespace Unity.Netcode.Transports.UTP
         /// <summary>
         /// Parameters for the Network Simulator
         /// </summary>
+        [Obsolete("SimulatorParameters are no longer used and have no effect. Use Network Simulator from the Multiplayer Tools package.", false)]
         [Serializable]
         public struct SimulatorParameters
         {

--- a/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
+++ b/com.unity.netcode.gameobjects/Runtime/Transports/UTP/UnityTransport.cs
@@ -61,7 +61,7 @@ namespace Unity.Netcode.Transports.UTP
         /// <summary>
         /// The default maximum send queue size
         /// </summary>
-        [Obsolete("MaxSendQueueSize is now determined dynamically (can still be set programmatically using the MaxSendQueueSize property). This initial value is not used anymore.", false)]
+        [Obsolete("MaxSendQueueSize is now determined dynamically (can still be set programmatically using the MaxSendQueueSize property). This initial value is not used anymore.", true)]
         public const int InitialMaxSendQueueSize = 16 * InitialMaxPayloadSize;
 
         // Maximum reliable throughput, assuming the full reliable window can be sent on every

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DocumentationCodeSamples/Configuration/CommandLineOptionsDocsTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DocumentationCodeSamples/Configuration/CommandLineOptionsDocsTests.cs
@@ -1,0 +1,46 @@
+using NUnit.Framework;
+using Unity.Netcode;
+
+namespace DocumentationCodeSamples
+{
+    internal class CommandLineOptionsDocsTests
+    {
+        #region DefineAndRead
+        private const string k_OverrideArg = "-argName";
+
+        private bool ParseCommandLineOptions(out string command)
+        {
+            if (CommandLineOptions.TryGetArg(k_OverrideArg, out var argValue))
+            {
+                command = argValue;
+                return true;
+            }
+            command = default;
+            return false;
+        }
+        #endregion
+
+        private string CommandLineUsage()
+        {
+            #region Usage
+            if (ParseCommandLineOptions(out var command))
+            {
+                // Your logic here
+            }
+            #endregion
+
+            return command;
+        }
+
+        [Test]
+        public void TestCommandLineUsage()
+        {
+            // This is a compile test.
+            var succeeded = ParseCommandLineOptions(out var command);
+            Assert.NotNull(succeeded);
+
+            var output = CommandLineUsage();
+            Assert.AreEqual(command, output);
+        }
+    }
+}

--- a/com.unity.netcode.gameobjects/Tests/Runtime/DocumentationCodeSamples/Configuration/CommandLineOptionsDocsTests.cs.meta
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/DocumentationCodeSamples/Configuration/CommandLineOptionsDocsTests.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: fe24c7026b40477c9941e9f7eca90a12
+timeCreated: 1788274882

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Rpc/RpcInvocationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Rpc/RpcInvocationTests.cs
@@ -98,13 +98,11 @@ namespace Unity.Netcode.RuntimeTests
             foreach (var (manager, instance) in m_InvokeInstances)
             {
                 instance.ExpectedCallCounts[nameof(InvokePermissionBehaviour.OwnerInvokePermissionRpc)] = 1;
-                instance.ExpectedCallCounts[nameof(InvokePermissionBehaviour.OwnerRequireOwnershipRpc)] = 1;
 
                 var threwException = false;
                 try
                 {
                     instance.OwnerInvokePermissionRpc();
-                    instance.OwnerRequireOwnershipRpc();
                 }
                 catch (RpcException)
                 {
@@ -178,10 +176,8 @@ namespace Unity.Netcode.RuntimeTests
             foreach (var (manager, instance) in m_InvokeInstances)
             {
                 instance.ExpectedCallCounts[nameof(InvokePermissionBehaviour.OwnerInvokePermissionRpc)] = 1;
-                instance.ExpectedCallCounts[nameof(InvokePermissionBehaviour.OwnerRequireOwnershipRpc)] = 1;
 
                 SendUncheckedMessage(manager, instance, nameof(InvokePermissionBehaviour.OwnerInvokePermissionRpc));
-                SendUncheckedMessage(manager, instance, nameof(InvokePermissionBehaviour.OwnerRequireOwnershipRpc));
             }
 
             yield return WaitForConditionOrTimeOut(AllExpectedCallsReceived);
@@ -460,13 +456,6 @@ namespace Unity.Netcode.RuntimeTests
 
         [Rpc(SendTo.Everyone, InvokePermission = RpcInvokePermission.Server)]
         public void ServerInvokePermissionRpc()
-        {
-            TrackRpcCalled(GetCaller());
-        }
-
-
-        [Rpc(SendTo.Everyone, InvokePermission = RpcInvokePermission.Owner)]
-        public void OwnerRequireOwnershipRpc()
         {
             TrackRpcCalled(GetCaller());
         }

--- a/com.unity.netcode.gameobjects/Tests/Runtime/Rpc/RpcInvocationTests.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/Rpc/RpcInvocationTests.cs
@@ -465,9 +465,7 @@ namespace Unity.Netcode.RuntimeTests
         }
 
 
-#pragma warning disable CS0618 // Type or member is obsolete
-        [Rpc(SendTo.Everyone, RequireOwnership = true)]
-#pragma warning restore CS0618 // Type or member is obsolete
+        [Rpc(SendTo.Everyone, InvokePermission = RpcInvokePermission.Owner)]
         public void OwnerRequireOwnershipRpc()
         {
             TrackRpcCalled(GetCaller());

--- a/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTestHelpers.cs
+++ b/com.unity.netcode.gameobjects/Tests/Runtime/TestHelpers/NetcodeIntegrationTestHelpers.cs
@@ -811,7 +811,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// <param name="networkObjectRoot"><see cref="GameObject"/></param>
         /// <param name="server"><see cref="NetworkManager"/></param>
         /// <param name="clients">An array of <see cref="NetworkManager"/>s</param>
-        [Obsolete("This method is no longer valid or used.", false)]
+        [Obsolete("This method is no longer valid or used.", true)]
         public static void MarkAsSceneObjectRoot(GameObject networkObjectRoot, NetworkManager server, NetworkManager[] clients)
         {
         }
@@ -1173,7 +1173,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// This method is no longer used.
         /// </summary>
         /// <param name="scenesProcessed"><see cref="Action"/></param>
-        [Obsolete("This method is deprecated and no longer used", false)]
+        [Obsolete("This method is deprecated and no longer used", true)]
         public static void SetRefreshAllPrefabsCallback(Action scenesProcessed)
         {
             NetworkObjectRefreshTool.AllScenesProcessed = scenesProcessed;
@@ -1184,7 +1184,7 @@ namespace Unity.Netcode.TestHelpers.Runtime
         /// </summary>
         /// <param name="networkObject"><see cref="NetworkObject"/></param>
         /// <param name="scenesProcessed"><see cref="Action"/></param>
-        [Obsolete("This method is deprecated and no longer used", false)]
+        [Obsolete("This method is deprecated and no longer used", true)]
         public static void RefreshAllPrefabInstances(NetworkObject networkObject, Action scenesProcessed)
         {
             NetworkObjectRefreshTool.AllScenesProcessed = scenesProcessed;


### PR DESCRIPTION
## Purpose of this PR
This PR is focusing on updating all obsolete APIs to throw errors for 3.X release which should happen around end of this week ([based on Emma doc](https://docs.google.com/spreadsheets/d/1o2ZlUpCxzARij6Wz0kE5COCAge6up9zz72ENvJG8_zw/edit?gid=210093807#gid=210093807)), 

Feel free to correct me on this PR

### Jira ticket
N/A

### Changelog
Deprecated: Several APIs that were already marked `[Obsolete]` with a warning now raise a compile error instead (they are not removed yet).

## Documentation
We did some docs corrections so we should double check when Amy is back

## Testing & QA (How your changes can be verified during release Playtest)
Green CI should be enough for this

## Up-port
N/A

## Backports
N/A
